### PR TITLE
fix(security): close production npm audit findings and harden inputs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,10 @@
 {
   "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
   "extends": [
-    "eslint:recommended"
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
   ],
   "parserOptions": {
     "ecmaVersion": 2022,
@@ -11,8 +14,11 @@
     "node": true,
     "es2022": true
   },
+  "ignorePatterns": ["dist/", "node_modules/", "*.js"],
   "rules": {
-    "no-unused-vars": "warn",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-explicit-any": "off",
     "prefer-const": "error",
     "no-console": ["warn", { "allow": ["warn", "error"] }]
   }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
     
     steps:
       - uses: actions/checkout@v4
@@ -96,15 +96,15 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
-          
+
       - name: Install dependencies
         run: npm ci
-        
+
       - name: Build TypeScript
         run: npm run build
-        
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 # Set working directory
 WORKDIR /app
 
-# Copy package files
+# Copy package files (package.json is also needed at runtime to read version)
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci --only=production
+# Install production dependencies
+RUN npm ci --omit=dev
 
 # Copy built application
 COPY dist/ ./dist/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest minor release line receives security updates.
+
+| Version | Supported |
+|---------|-----------|
+| 1.1.x   | ✅        |
+| < 1.1   | ❌        |
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security problems.**
+
+If you believe you have found a security vulnerability in `pagespeed-insights-mcp`, report it privately via one of:
+
+- GitHub's [Private Vulnerability Reporting](https://github.com/ruslanlap/pagespeed-insights-mcp/security/advisories/new) for this repository (preferred).
+- Email the maintainer listed in `package.json` / GitHub profile.
+
+Please include:
+
+- A clear description of the issue and its impact.
+- Steps to reproduce, ideally with a minimal proof of concept.
+- The affected version(s).
+- Any suggested remediation, if you have one.
+
+### Response timeline
+
+- **Acknowledgement:** within 5 business days.
+- **Initial assessment:** within 10 business days.
+- **Fix or mitigation plan:** communicated as soon as the severity and scope are understood.
+
+We will credit reporters in the release notes unless anonymity is requested.
+
+## Out of Scope
+
+This project is an MCP server that calls the Google PageSpeed Insights and Chrome UX Report APIs. The following are **not** considered in scope:
+
+- Vulnerabilities in Google's APIs themselves.
+- Issues that require attacker-controlled `GOOGLE_API_KEY` to exploit (the key is a secret managed by the operator).
+- Denial of service caused by Google API quota exhaustion.
+- Findings against the demo HTML page hosted on GitHub Pages.
+
+## Hardening Notes for Operators
+
+- Treat `GOOGLE_API_KEY` as a secret. Never commit it to source control. Use `.env`, your shell, or your MCP client's secret store.
+- The server is designed for `stdio` transport; do not expose its standard streams over the network without your own authentication layer.
+- Restrict your Google API key to the PageSpeed Insights and Chrome UX Report APIs in the Google Cloud Console.

--- a/claude-desktop-config.json
+++ b/claude-desktop-config.json
@@ -1,21 +1,11 @@
 {
   "mcpServers": {
-    "Context7": {
+    "pagespeed-insights": {
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"]
-    },
-    "pagespeed": {
-      "command": "npx",
-      "args": ["pagespeed-insights-mcp"],
+      "args": ["-y", "@ruslanlap/pagespeed-insights-mcp"],
       "env": {
-        "GOOGLE_API_KEY": "here"
+        "GOOGLE_API_KEY": "YOUR_GOOGLE_API_KEY_HERE"
       }
-    }
-  },
-  "mcp": {
-    "pagespeed": {
-      "run-pagespeed": "analyze_page_speed",
-      "get-performance-summary": "get_performance_summary"
     }
   }
 }

--- a/install.sh
+++ b/install.sh
@@ -49,8 +49,9 @@ fi
 print_status "Node.js version $NODE_VERSION detected"
 
 # Install the MCP server globally
-print_info "Installing pagespeed-insights-mcp globally..."
-npm install -g pagespeed-insights-mcp
+PACKAGE_NAME="@ruslanlap/pagespeed-insights-mcp"
+print_info "Installing ${PACKAGE_NAME} globally..."
+npm install -g "${PACKAGE_NAME}"
 
 print_status "MCP server installed successfully!"
 

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ print_info() {
 
 # Check if Node.js is installed
 if ! command -v node &> /dev/null; then
-    print_error "Node.js is not installed. Please install Node.js 18+ from https://nodejs.org/"
+    print_error "Node.js is not installed. Please install Node.js 20+ from https://nodejs.org/"
     exit 1
 fi
 
@@ -41,8 +41,8 @@ fi
 NODE_VERSION=$(node -v | cut -d'v' -f2)
 NODE_MAJOR=$(echo $NODE_VERSION | cut -d'.' -f1)
 
-if [ "$NODE_MAJOR" -lt 18 ]; then
-    print_error "Node.js version 18 or higher is required. Current version: $NODE_VERSION"
+if [ "$NODE_MAJOR" -lt 20 ]; then
+    print_error "Node.js version 20 or higher is required. Current version: $NODE_VERSION"
     exit 1
 fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "node-fetch": "^3.3.2",
         "p-limit": "^4.0.0",
         "p-retry": "^6.1.0",
@@ -605,9 +605,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -686,9 +686,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -726,9 +726,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2427,9 +2427,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3958,12 +3958,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -4072,9 +4072,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -4698,9 +4698,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.11.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
-      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -4930,9 +4930,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -9647,9 +9647,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -9980,9 +9980,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -801,6 +801,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -2018,6 +2019,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2348,6 +2350,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3636,6 +3639,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4698,6 +4702,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5447,6 +5452,7 @@
       "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -10553,6 +10559,7 @@
       "integrity": "sha512-kz76azHrT8+VEkQjoCBHE06JNQgTgsC4bT8XfCzb7DHcsk9vG3fqeMVik8h5rcWCYi2Fd+M3bwA7BG8Z8cRwtA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^10.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -11640,6 +11647,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11721,6 +11729,7 @@
       "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -11806,6 +11815,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11943,6 +11953,7 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -12036,6 +12047,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12293,6 +12305,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
-    "lint": "echo 'Linting skipped for now'",
+    "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "format": "prettier --write src/**/*.ts",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "url": "https://github.com/ruslanlap/pagespeed-insights-mcp/issues"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "node-fetch": "^3.3.2",
     "p-limit": "^4.0.0",
     "p-retry": "^6.1.0",
@@ -72,7 +72,7 @@
     "vitest": "^4.0.12"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,5 +1,4 @@
 import { getLogger } from "./logger.js";
-import type { PageSpeedInsightsResponse, CruxRecord } from "./types.js";
 
 const logger = getLogger();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import { randomUUID } from "crypto";
+import { createRequire } from "module";
 import { validateEnv } from "./env.js";
 import { getLogger, createRequestLogger } from "./logger.js";
 import { PageSpeedClient } from "./pagespeed-client.js";
@@ -24,6 +25,8 @@ import {
 } from "./schemas.js";
 import type { PageSpeedInsightsResponse, CruxRecord, ComparisonResult } from "./types.js";
 
+const pkg = createRequire(import.meta.url)("../package.json") as { version: string };
+
 class PageSpeedInsightsServer {
   private server: Server;
   private client: PageSpeedClient;
@@ -37,7 +40,7 @@ class PageSpeedInsightsServer {
     this.server = new Server(
       {
         name: "pagespeed-insights-mcp",
-        version: "1.0.6",
+        version: pkg.version,
       },
       {
         capabilities: {

--- a/src/pagespeed-client.ts
+++ b/src/pagespeed-client.ts
@@ -26,13 +26,17 @@ export class PageSpeedClient {
     this.limiter = pLimit(env.MAX_CONCURRENCY);
   }
 
+  // Strip the API key out of anything that may end up in logs or error traces.
+  private redact(text: string): string {
+    return text.replaceAll(this.apiKey, "[REDACTED]");
+  }
 
   private async makeRequest(url: string, correlationId: string): Promise<any> {
     const logger = createRequestLogger(correlationId, "psi-request");
-    
+
     return pRetry(
       async (attempt) => {
-        logger.debug({ attempt, url }, "Making PSI request");
+        logger.debug({ attempt, url: this.redact(url) }, "Making PSI request");
         
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), this.timeout);
@@ -70,7 +74,7 @@ export class PageSpeedClient {
         } catch (error) {
           clearTimeout(timeoutId);
           const errorMessage = error instanceof Error ? error.message : "Unknown error";
-          logger.warn({ attempt, error: errorMessage }, "PSI request failed");
+          logger.warn({ attempt, error: this.redact(errorMessage) }, "PSI request failed");
           throw error;
         }
       },
@@ -178,7 +182,7 @@ export class PageSpeedClient {
       } catch (error) {
         clearTimeout(timeoutId);
         const errorMessage = error instanceof Error ? error.message : "Unknown error";
-        logger.warn({ error: errorMessage }, "CrUX request failed");
+        logger.warn({ error: this.redact(errorMessage) }, "CrUX request failed");
         throw error;
       }
     });

--- a/src/response-parser.ts
+++ b/src/response-parser.ts
@@ -1,6 +1,5 @@
 import type {
   PageSpeedInsightsResponse,
-  LighthouseAudit,
   ElementNode,
   NetworkRequest,
   JavaScriptExecutionItem,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,6 +1,19 @@
 import { z } from "zod";
 
-export const UrlSchema = z.string().url("Must be a valid URL");
+export const UrlSchema = z
+  .string()
+  .url("Must be a valid URL")
+  .refine(
+    (value) => {
+      try {
+        const { protocol } = new URL(value);
+        return protocol === "http:" || protocol === "https:";
+      } catch {
+        return false;
+      }
+    },
+    { message: "URL must use http:// or https:// scheme" },
+  );
 
 export const StrategySchema = z.enum(["mobile", "desktop"]).default("mobile");
 

--- a/test-mcp.js
+++ b/test-mcp.js
@@ -3,12 +3,17 @@
 import { spawn } from 'child_process';
 import { createInterface } from 'readline';
 
-// Start the MCP server
+if (!process.env.GOOGLE_API_KEY) {
+  console.error('❌ GOOGLE_API_KEY environment variable is required');
+  console.error('   Set it before running this script, e.g.:');
+  console.error('     macOS/Linux:  export GOOGLE_API_KEY="your-key"');
+  console.error('     Windows PS:   $env:GOOGLE_API_KEY="your-key"');
+  process.exit(1);
+}
+
+// Start the MCP server (inherits GOOGLE_API_KEY from current env)
 const server = spawn('node', ['dist/index.js'], {
-  env: {
-    ...process.env,
-    GOOGLE_API_KEY: 'AIzaSjAD7mURoGVIUcFcAizg' // Replace with your actual API key
-  }
+  env: process.env
 });
 
 // Create readline interface for server's stdout

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "node",
     "strict": true,
@@ -14,5 +14,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/tests"]
 }


### PR DESCRIPTION
## Summary

Phase 2 of the audit pass — focused on security. Builds on top of #7 (Phase 1 cleanup); if you'd like that one merged first, this PR can be rebased afterwards to drop the Phase 1 commit.

Three groups of changes, all small:

### Supply chain — 8 prod advisories → 0
- Bumped `@modelcontextprotocol/sdk` to `^1.29.0`, then ran `npm audit fix` to pull patched transitives:
  - `@hono/node-server` 1.19.9 → 1.19.14 (authorization bypass via encoded slashes, GHSA-wc8c-qw6v-h7f6)
  - `path-to-regexp` 8.3.0 → 8.4.2 (ReDoS x2, GHSA-j3q9-mxjg-w52f, GHSA-27v5-c462-wpq7)
  - `qs` 6.14.2 → 6.15.2 (DoS, GHSA-q8mj-m7cp-5q26)
- `npm audit --omit=dev` now reports **0 vulnerabilities**, down from 8 (5 high / 3 moderate).

### Input hardening
- **`src/schemas.ts`** — `UrlSchema` previously accepted any URI Zod considered "valid": `file://`, `ftp://`, `javascript:` etc. all passed. Added a `.refine` that rejects everything other than `http:` and `https:`. Google's APIs would have refused most of them, but failing in the MCP boundary gives a clearer error and removes a soft SSRF foot-gun.
- **`src/pagespeed-client.ts`** — `GOOGLE_API_KEY` is passed in the query string for both the PSI and CrUX endpoints (the APIs accept nothing else). The debug log of the full request URL and the `error.message` of caught fetch failures could therefore echo the key into `pino` output. Added a small `redact()` helper and applied it to both call sites in both endpoints. Verified manually that the URL and error fields are now `[REDACTED]` in the affected places.

### Runtime baseline
- Bumped Node baseline from 18 to 20 LTS. Node 18 reached EOL in April 2025.
  - `package.json` `engines.node` → `>=20`
  - `install.sh` Node version guard → 20+
  - `Dockerfile` `FROM node:18-alpine` → `node:20-alpine`
  - CI matrix `[18, 20, 22]` → `[20, 22, 24]`
  - Docker job `setup-node` 18 → 20
- `tsconfig.json` `target` ES2020 → ES2022 (Node 20 supports it fully; needed for the `replaceAll` used by the redact helper).
- Also excluded `src/tests` from build output — previously `npm run build` was compiling tests into `dist/tests/`, and Vitest was then running them a second time. Side effect of the same change.

### Documentation
- New `SECURITY.md` with private-disclosure policy, supported-version table, and operator hardening notes (don't expose stdio, scope your Google API key, etc.).

### Drive-by
- `Dockerfile` replaced deprecated `npm ci --only=production` with `npm ci --omit=dev`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 3/3 pass
- [x] `npm run build` — clean, no longer emits tests into dist/
- [x] `npm audit --omit=dev` — 0 vulnerabilities (was 8)
- [x] `UrlSchema.safeParse` manually exercised against http(s), file, ftp, javascript schemes — only http(s) pass
- [x] Runtime version still resolves correctly via `createRequire` (from #7)

## Notes / out of scope

Still on the followup list from the audit (kept out of this PR to keep the diff focused):

- Lighthouse `pwa` category was removed in 2024; schemas + handlers still reference it.
- FID is no longer a Core Web Vital — it was replaced by INP (Interaction to Next Paint) in March 2024. Formatters / summaries should be updated.
- README still references the unscoped npm name and a few of the bumped Node version numbers.
- Test coverage is very thin (only `pagespeed-client.test.ts`); 1600 lines of MCP tool handlers and the recommendations engine have no tests.

Happy to send those as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)