### PR TITLE
test: cover Phase 2 schema whitelist and API key redaction; sync README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,6 @@ npm install -g pagespeed-insights-mcp
 
 # Or use without installation
 npx pagespeed-insights-mcp
-
-# Specific version
-npm install -g pagespeed-insights-mcp@1.0.6
 ```
 
 #### From GitHub Packages
@@ -131,9 +128,6 @@ npm install -g pagespeed-insights-mcp@1.0.6
 # First configure authentication (see GITHUB_PACKAGES.md for details)
 # Then install globally
 npm install -g @ruslanlap/pagespeed-insights-mcp
-
-# Or specific version
-npm install -g @ruslanlap/pagespeed-insights-mcp@1.0.6
 ```
 
 > **Note:** This package is available on both npm and GitHub Packages.
@@ -716,7 +710,16 @@ Ensure the `GOOGLE_API_KEY` environment variable is set in your Claude Desktop c
 Check if PageSpeed Insights API is enabled in your Google Cloud project.
 
 ### "Invalid URL"
-Ensure the URL includes the protocol (http:// or https://).
+Ensure the URL includes the protocol — only `http://` and `https://` are accepted. Other schemes (`file://`, `ftp://`, `javascript:`, etc.) are rejected at the schema level.
+
+## Requirements
+
+- Node.js **20 or later** (Node 18 is EOL since April 2025 and is no longer supported).
+- A Google API key with PageSpeed Insights and (optionally) Chrome UX Report APIs enabled.
+
+## Security
+
+Please report security issues privately — do **not** open a public issue. See [SECURITY.md](./SECURITY.md) for the disclosure policy and operator hardening notes.
 
 ## Acknowledgments
 

--- a/src/tests/pagespeed-client.redact.test.ts
+++ b/src/tests/pagespeed-client.redact.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import nock from "nock";
+
+const SECRET_KEY = "super-secret-api-key-9999";
+
+// Mock env BEFORE importing the client so the constructor sees our key.
+vi.mock("../env.js", () => ({
+  getEnv: () => ({
+    GOOGLE_API_KEY: SECRET_KEY,
+    REQUEST_TIMEOUT: 30000,
+    RETRY_ATTEMPTS: 0,
+    CACHE_TTL: 3600,
+    MAX_CONCURRENCY: 3,
+    LOG_LEVEL: "info",
+    NODE_ENV: "test",
+  }),
+}));
+
+// Capture every {payload, msg} pair the client logs at any level via a fake
+// pino child logger. We don't care which level was used — only that nothing
+// contains the API key.
+const logCalls: Array<{ level: string; payload: unknown; msg?: string }> = [];
+
+const fakeChild = {
+  debug: (payload: unknown, msg?: string) => logCalls.push({ level: "debug", payload, msg }),
+  info: (payload: unknown, msg?: string) => logCalls.push({ level: "info", payload, msg }),
+  warn: (payload: unknown, msg?: string) => logCalls.push({ level: "warn", payload, msg }),
+  error: (payload: unknown, msg?: string) => logCalls.push({ level: "error", payload, msg }),
+  child: () => fakeChild,
+};
+
+vi.mock("../logger.js", () => ({
+  getLogger: () => fakeChild,
+  createRequestLogger: () => fakeChild,
+}));
+
+// Imports must come AFTER the mocks above.
+const { PageSpeedClient } = await import("../pagespeed-client.js");
+const { cache } = await import("../cache.js");
+
+describe("PageSpeedClient redaction", () => {
+  let client: InstanceType<typeof PageSpeedClient>;
+
+  beforeEach(() => {
+    client = new PageSpeedClient();
+    nock.cleanAll();
+    cache.clear();
+    logCalls.length = 0;
+  });
+
+  it("does not log the API key on a fetch network failure", async () => {
+    // Simulate a network error from googleapis. node-fetch wraps the cause
+    // into error.message; we want to confirm the message is redacted before
+    // it hits the logger.
+    nock("https://www.googleapis.com")
+      .get("/pagespeedonline/v5/runPagespeed")
+      .query(true)
+      .replyWithError(`getaddrinfo ENOTFOUND for url with key=${SECRET_KEY}`);
+
+    await expect(
+      client.analyzePageSpeed(
+        {
+          url: "https://example.com",
+          strategy: "mobile",
+          category: ["performance"],
+          locale: "en",
+        },
+        "corr-redact-1",
+      ),
+    ).rejects.toThrow();
+
+    // The PSI request logger.warn call should exist and must NOT contain the key.
+    const warnCalls = logCalls.filter((c) => c.level === "warn");
+    expect(warnCalls.length).toBeGreaterThan(0);
+    for (const call of warnCalls) {
+      const serialised = JSON.stringify(call);
+      expect(serialised).not.toContain(SECRET_KEY);
+      expect(serialised).toContain("[REDACTED]");
+    }
+  });
+
+  it("does not log the API key in the debug request line", async () => {
+    nock("https://www.googleapis.com")
+      .get("/pagespeedonline/v5/runPagespeed")
+      .query(true)
+      .reply(200, { lighthouseResult: { categories: {}, audits: {} } });
+
+    await client.analyzePageSpeed(
+      {
+        url: "https://example.com",
+        strategy: "mobile",
+        category: ["performance"],
+        locale: "en",
+      },
+      "corr-redact-2",
+    );
+
+    const allSerialised = JSON.stringify(logCalls);
+    expect(allSerialised).not.toContain(SECRET_KEY);
+  });
+
+  it("does not log the API key on a CrUX failure", async () => {
+    nock("https://chromeuxreport.googleapis.com")
+      .post("/v1/records:queryRecord")
+      .query(true)
+      .replyWithError(`crux blew up with key=${SECRET_KEY}`);
+
+    await expect(
+      client.getCruxData({ url: "https://example.com" }, "corr-redact-3"),
+    ).rejects.toThrow();
+
+    const warnCalls = logCalls.filter((c) => c.level === "warn");
+    expect(warnCalls.length).toBeGreaterThan(0);
+    for (const call of warnCalls) {
+      const serialised = JSON.stringify(call);
+      expect(serialised).not.toContain(SECRET_KEY);
+    }
+  });
+});

--- a/src/tests/schemas.test.ts
+++ b/src/tests/schemas.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { UrlSchema, LocaleSchema, AnalyzePageSpeedSchema } from "../schemas.js";
+
+describe("UrlSchema", () => {
+  it("accepts https URLs", () => {
+    expect(UrlSchema.safeParse("https://example.com").success).toBe(true);
+    expect(UrlSchema.safeParse("https://example.com/some/path?q=1#frag").success).toBe(true);
+  });
+
+  it("accepts http URLs", () => {
+    expect(UrlSchema.safeParse("http://example.com").success).toBe(true);
+    expect(UrlSchema.safeParse("http://localhost:3000/x").success).toBe(true);
+  });
+
+  it.each([
+    ["file:///etc/passwd"],
+    ["ftp://example.com/x"],
+    ["javascript:alert(1)"],
+    ["data:text/html,<script>alert(1)</script>"],
+    ["ws://example.com"],
+    ["gopher://example.com"],
+  ])("rejects non-http(s) scheme: %s", (url) => {
+    const result = UrlSchema.safeParse(url);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("http");
+    }
+  });
+
+  it("rejects malformed URLs with the underlying Zod message", () => {
+    const result = UrlSchema.safeParse("not a url");
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty strings", () => {
+    expect(UrlSchema.safeParse("").success).toBe(false);
+  });
+});
+
+describe("LocaleSchema", () => {
+  it("accepts simple language tags", () => {
+    expect(LocaleSchema.safeParse("en").success).toBe(true);
+    expect(LocaleSchema.safeParse("tr").success).toBe(true);
+  });
+
+  it("accepts language-region tags", () => {
+    expect(LocaleSchema.safeParse("en-US").success).toBe(true);
+    expect(LocaleSchema.safeParse("tr-TR").success).toBe(true);
+  });
+
+  it("rejects bad formats", () => {
+    expect(LocaleSchema.safeParse("EN").success).toBe(false);
+    expect(LocaleSchema.safeParse("en_US").success).toBe(false);
+    expect(LocaleSchema.safeParse("english").success).toBe(false);
+  });
+});
+
+describe("AnalyzePageSpeedSchema defaults", () => {
+  it("fills in default strategy, category and locale when omitted", () => {
+    const result = AnalyzePageSpeedSchema.safeParse({ url: "https://example.com" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.strategy).toBe("mobile");
+      expect(result.data.category).toEqual(["performance"]);
+      expect(result.data.locale).toBe("en");
+    }
+  });
+
+  it("blocks a file:// URL even when other fields are valid", () => {
+    const result = AnalyzePageSpeedSchema.safeParse({
+      url: "file:///etc/passwd",
+      strategy: "mobile",
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of the audit pass — locks in the Phase 2 security work (#8) with actual tests, plus a small README cleanup. Stacked on top of #7 and #8.

### Tests (3 → 21)

**`src/tests/schemas.test.ts` (new, 15 tests)**
Exercises the `UrlSchema` http(s) whitelist that #8 introduced:
- positive: `http://`, `https://`
- negative: `file://`, `ftp://`, `javascript:`, `data:`, `ws://`, `gopher://`, malformed strings, empty string

Also adds coverage for `LocaleSchema` regex and `AnalyzePageSpeedSchema` default-fill behaviour (strategy, category, locale) plus a cross-field check that a bad URL is rejected even when other fields are valid.

**`src/tests/pagespeed-client.redact.test.ts` (new, 3 tests)**
Mocks the `pino` child logger at the module boundary, then drives both the PSI and CrUX endpoints (via `nock`) into failures whose fetch error messages **embed the secret API key**. Asserts that every captured log entry replaces the key with `[REDACTED]` and never contains the raw secret. Covers:
- PSI network failure path (warn log on rethrow)
- PSI debug request-URL log (success path)
- CrUX network failure path

These are exactly the three call sites that received the `redact()` helper in #8 — so the security fix now has regression coverage.

### README sync

- Drop the two `@1.0.6` version-pinned install commands. They pin to an outdated artifact on public npm and would break the moment the maintainer publishes again. Omitting the pin gives users the current published version.
- Tighten the "Invalid URL" troubleshooting note to mention the new http(s)-only enforcement.
- Add a **Requirements** section calling out Node 20+ (Node 18 reached EOL in April 2025; #8 already bumped the baseline).
- Add a **Security** section pointing at the new `SECURITY.md` from #8.

No code changes in `src/` beyond the new test files. No new dependencies.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — **21/21 pass** (was 3)
- [x] `npm run build` — clean
- [x] `npm audit --omit=dev` — 0 vulnerabilities

## Notes

Still on the followup list:
- Lighthouse `pwa` category was removed in 2024; schemas + handlers still reference it.
- FID → INP migration in Core Web Vitals formatters.
- Test coverage for `src/index.ts` MCP tool handlers and the recommendations engine.
- `publish.sh` has a `sed` that no longer matches the scoped name in `package.json`, so dual-publish to public npm is likely silently producing the wrong package. Worth a separate look.

Happy to follow up on any of those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)