### PR TITLE
fix(publish): repair dual-registry publish so public npm gets new versions

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,47 +1,69 @@
 #!/bin/bash
-set -e
+# Dual-publish the package to:
+#   1. Public npm   (unscoped name)
+#   2. GitHub Packages (scoped name)
+#
+# Usage: GITHUB_TOKEN=ghp_xxx ./publish.sh
+#        (additionally requires `npm login` for the public-npm step)
+#
+# Assumes package.json's canonical state is the scoped name with
+# publishConfig.registry pointing at GitHub Packages. The script
+# temporarily swaps the name + publishConfig for the public-npm step
+# and ALWAYS restores the original via a trap, even on failure.
 
-# Check if GITHUB_TOKEN is set
-if [ -z "$GITHUB_TOKEN" ]; then
-  echo "❌ Error: GITHUB_TOKEN environment variable is not set"
-  echo "Please set it with: export GITHUB_TOKEN=your_personal_access_token"
+set -euo pipefail
+
+PUBLIC_NAME="pagespeed-insights-mcp"
+SCOPED_NAME="@ruslanlap/pagespeed-insights-mcp"
+
+# ── Pre-flight ──────────────────────────────────────────────────────────
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "❌ GITHUB_TOKEN is not set. Required for the GitHub Packages step."
+  echo "   Set it with: export GITHUB_TOKEN=your_personal_access_token"
   exit 1
 fi
 
-# Get version from package.json
-VERSION=$(node -p "require('./package.json').version")
-echo "📦 Publishing version $VERSION"
+ORIGINAL_NAME=$(node -p "require('./package.json').name")
+if [ "$ORIGINAL_NAME" != "$SCOPED_NAME" ]; then
+  echo "❌ package.json name is '$ORIGINAL_NAME', expected '$SCOPED_NAME'."
+  echo "   This script assumes the canonical name in package.json is the scoped one."
+  exit 1
+fi
 
-# Build the package
+VERSION=$(node -p "require('./package.json').version")
+echo "📦 Publishing version $VERSION to both registries"
+
+# ── Build ───────────────────────────────────────────────────────────────
 echo "🔨 Building package..."
 npm run build
 
-# Save original package.json
+# ── Safety: always restore package.json on exit ─────────────────────────
 cp package.json package.json.backup
+trap 'mv -f package.json.backup package.json 2>/dev/null || true' EXIT
 
-# 1. Publish to npm
-echo "🚀 Publishing to npm registry..."
+# ── 1. Public npm (unscoped) ────────────────────────────────────────────
+echo "🚀 Publishing $PUBLIC_NAME@$VERSION to public npm..."
+# `npm pkg` does proper JSON edits — no sed escaping pitfalls.
+npm pkg set "name=$PUBLIC_NAME"
+npm pkg delete publishConfig
+npm publish --access=public --registry=https://registry.npmjs.org/
+
+# ── 2. GitHub Packages (scoped) ─────────────────────────────────────────
+echo "🔄 Restoring canonical package.json for GitHub Packages step..."
+mv -f package.json.backup package.json
+cp package.json package.json.backup  # re-stash so the trap still has a copy
+
+echo "🚀 Publishing $SCOPED_NAME@$VERSION to GitHub Packages..."
 npm publish
 
-# 2. Prepare for GitHub Packages
-echo "🔄 Preparing for GitHub Packages..."
-sed -i 's/"name": "pagespeed-insights-mcp"/"name": "@ruslanlap\/pagespeed-insights-mcp"/g' package.json
-sed -i 's/"access": "public"/"registry": "https:\/\/npm.pkg.github.com"/g' package.json
-
-# 3. Publish to GitHub Packages
-echo "🚀 Publishing to GitHub Packages..."
-npm publish
-
-# 4. Restore original package.json
-echo "🔄 Restoring original package.json..."
-mv package.json.backup package.json
+# ── Done ────────────────────────────────────────────────────────────────
+# Trap restores package.json on exit; nothing more to do here.
 
 echo ""
-echo "✅ Successfully published to both registries!"
-echo "📦 npm: https://www.npmjs.com/package/pagespeed-insights-mcp"
-echo "📦 GitHub: https://github.com/ruslanlap/pagespeed-insights-mcp/packages"
+echo "✅ Successfully published $VERSION to both registries"
+echo "📦 npm:    https://www.npmjs.com/package/$PUBLIC_NAME/v/$VERSION"
+echo "📦 GitHub: https://github.com/ruslanlap/pagespeed-insights-mcp/pkgs/npm/pagespeed-insights-mcp"
 echo ""
-echo "📋 Installation instructions:"
-echo "   npm: npm install pagespeed-insights-mcp@$VERSION"
-echo "   GitHub: npm install @ruslanlap/pagespeed-insights-mcp@$VERSION"
-echo "          (requires GitHub authentication)"
+echo "📋 Installation:"
+echo "   npm:    npm install $PUBLIC_NAME@$VERSION"
+echo "   GitHub: npm install $SCOPED_NAME@$VERSION   (requires GitHub authentication)"


### PR DESCRIPTION
## Summary

`publish.sh` has been silently no-op'ing the public-npm step. The script's `sed` lines look for the unscoped name in `package.json`, but `package.json` already carries the scoped name as its canonical state (with `publishConfig.registry` pointing at GitHub Packages). Both `sed` calls match nothing, and the first `npm publish` ships the *scoped* package to whichever registry `publishConfig` names — which means **public npm has been stuck on `pagespeed-insights-mcp@1.0.6`** while GitHub Packages keeps rolling forward via semantic-release.

Users following the README's primary install path (`npm install -g pagespeed-insights-mcp` on public npm) are landing on the 2024 version that pre-dates Phase 1/2 fixes.

## What changed

Rewrote `publish.sh`. Same intent, working implementation, plus a few safety improvements:

- **`npm pkg set` / `npm pkg delete`** instead of `sed`. Proper JSON edits, no escaping pitfalls, no risk of corrupting the file when keys gain whitespace or quoting changes.
- **Pre-flight check** that the canonical name really is the scoped one. Fails loudly with a clear message if the starting state drifts again.
- **`trap '… EXIT'`** restores `package.json` from the backup even if a `npm publish` call fails partway through. The old script could leave the repo in a half-mutated state.
- **`set -euo pipefail`** for general hygiene.
- **Explicit `--registry=https://registry.npmjs.org/`** on the public-npm publish so it doesn't accidentally inherit any local `npm config` pointing elsewhere.

CI is **not** changed. The GitHub Packages auto-release via semantic-release keeps working exactly as today. After this lands, you can run `GITHUB_TOKEN=… ./publish.sh` once to catch public npm up to 1.1.2, and the same command on subsequent releases.

## Test plan

- [x] `bash -n publish.sh` — syntax clean
- [x] Dry-run the JSON manipulation against a copy of the real `package.json`:
  - before: `name=@ruslanlap/pagespeed-insights-mcp`, `publishConfig.registry=https://npm.pkg.github.com`
  - after `npm pkg set name=… && npm pkg delete publishConfig`: `name=pagespeed-insights-mcp`, no `publishConfig`
- [x] `npm run typecheck` / `lint` / `test` (30/30) / `npm audit --omit=dev` — all green (publish.sh is standalone; included for sanity)

I deliberately did **not** run the actual `npm publish` against either registry — that's the maintainer's call to make from a trusted environment.

## Follow-up suggestion (separate PR if you want)

The cleanest long-term version is to wire the public-npm step into the existing `release` job in `.github/workflows/ci.yml`, right after the `semantic-release` step. That removes the manual nudge entirely. Happy to send that as a separate PR — wanted to keep this one focused on fixing the immediate bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)