### PR TITLE
Add symlink-safe entrypoint detection (`isProcessEntrypoint`) and tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import { randomUUID } from "crypto";
+import { realpathSync } from "fs";
 import { createRequire } from "module";
 import { fileURLToPath } from "url";
 import { validateEnv } from "./env.js";
@@ -1612,14 +1613,16 @@ export class PageSpeedInsightsServer {
 // Only auto-start when this file is the process entry point. When imported
 // by tests the autostart is skipped, so the suite can construct the server
 // without a real stdio transport hanging around.
-const isMain = (() => {
-  if (!process.argv[1]) return false;
+export function isProcessEntrypoint(moduleUrl: string, argv1?: string): boolean {
+  if (!argv1) return false;
   try {
-    return fileURLToPath(import.meta.url) === process.argv[1];
+    return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(argv1);
   } catch {
     return false;
   }
-})();
+}
+
+const isMain = isProcessEntrypoint(import.meta.url, process.argv[1]);
 
 if (isMain) {
   const server = new PageSpeedInsightsServer();

--- a/src/tests/index.entrypoint.test.ts
+++ b/src/tests/index.entrypoint.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { pathToFileURL } from "url";
+
+vi.mock("../env.js", () => ({
+  validateEnv: () => {},
+  getEnv: () => ({
+    GOOGLE_API_KEY: "test",
+    REQUEST_TIMEOUT: 30000,
+    RETRY_ATTEMPTS: 0,
+    CACHE_TTL: 3600,
+    MAX_CONCURRENCY: 3,
+    LOG_LEVEL: "info",
+    NODE_ENV: "test",
+  }),
+}));
+
+vi.mock("../logger.js", () => {
+  const fakeChild = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => fakeChild,
+  };
+  return { getLogger: () => fakeChild, createRequestLogger: () => fakeChild };
+});
+
+const { isProcessEntrypoint } = await import("../index.js");
+
+describe("isProcessEntrypoint", () => {
+  it("returns true when argv[1] is a symlink to the entry file", () => {
+    const root = mkdtempSync(join(tmpdir(), "psi-entrypoint-"));
+    try {
+      const realDir = join(root, "real");
+      mkdirSync(realDir);
+      const realFile = join(realDir, "index.js");
+      writeFileSync(realFile, "#!/usr/bin/env node\n");
+
+      const binShim = join(root, "pagespeed-insights-mcp");
+      symlinkSync(realFile, binShim);
+
+      const moduleUrl = pathToFileURL(realFile).href;
+      expect(isProcessEntrypoint(moduleUrl, binShim)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns false when argv[1] points to a different file", () => {
+    const root = mkdtempSync(join(tmpdir(), "psi-entrypoint-"));
+    try {
+      const a = join(root, "a.js");
+      const b = join(root, "b.js");
+      writeFileSync(a, "a\n");
+      writeFileSync(b, "b\n");
+      expect(isProcessEntrypoint(pathToFileURL(a).href, b)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns false when argv[1] is missing", () => {
+    const moduleUrl = pathToFileURL(join(tmpdir(), "ghost.js")).href;
+    expect(isProcessEntrypoint(moduleUrl)).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation

- Ensure the module-only auto-start check works correctly when the process argv[1] is a symlink to the real entry file, and make the logic testable without a real stdio transport.

### Description

- Introduce and export a new `isProcessEntrypoint(moduleUrl: string, argv1?: string): boolean` helper that compares `realpathSync(fileURLToPath(moduleUrl))` to `realpathSync(argv1)` to handle symlinks reliably. 
- Import `realpathSync` from `fs` and replace the inlined `isMain` IIFE with a call to `isProcessEntrypoint(import.meta.url, process.argv[1])` to preserve previous behavior while allowing tests to call the function directly. 
- Add `src/tests/index.entrypoint.test.ts` with `vitest` tests covering a symlinked argv, a different file argv, and a missing `argv[1]`, and include mocks for `env` and `logger` to avoid side effects during import. 

### Testing

- Added and ran the new `vitest` test suite file `src/tests/index.entrypoint.test.ts`, which includes three assertions for symlinked entry, non-matching entry, and missing `argv[1]`, and all tests passed.
- Existing test harness was used with mocks for `validateEnv` and logger utilities to avoid requiring external services, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16930d866c832bb501d983a836ce7c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/pagespeed-insights-mcp/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->