### PR TITLE
chore(release): v1.2.3 — add Antigravity docs and patch-release rules

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,21 @@
 {
   "branches": ["master"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "type": "docs", "scope": "antigravity", "release": "patch" },
+          { "type": "docs", "scope": "integration", "release": "patch" },
+          { "type": "docs", "scope": "integrations", "release": "patch" },
+          { "type": "docs", "scope": "mcp-client", "release": "patch" },
+          { "type": "docs", "scope": "mcp-clients", "release": "patch" },
+          { "type": "docs", "scope": "configuration", "release": "patch" },
+          { "type": "docs", "scope": "config", "release": "patch" },
+          { "type": "docs", "scope": "examples", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.2.3](https://github.com/ruslanlap/pagespeed-insights-mcp/compare/v1.2.2...v1.2.3) (2026-05-31)
+
+
+### Documentation
+
+* **antigravity:** add Google Antigravity MCP configuration example and README setup guide ([ed0feea](https://github.com/ruslanlap/pagespeed-insights-mcp/commit/ed0feea8018e6b879e0795e7140cfdb112a81c00))
+* **release:** document user-facing release notes in README and patch-release rules for important integration docs
+
 ## [1.2.2](https://github.com/ruslanlap/pagespeed-insights-mcp/compare/v1.2.1...v1.2.2) (2026-05-28)
 
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   - [Claude Desktop](#claude-desktop)
   - [Codex / OpenAI](#codex--openai)
 - [📚 Documentation](#-documentation)
+- [📝 Release Notes](#-release-notes)
 - [✨ Features](#-features)
   - [Core Features](#core-features)
   - [Advanced Analysis Tools (New!)](#advanced-analysis-tools-new)
@@ -159,6 +160,18 @@ We have comprehensive documentation available online.
 - [🏗️ **Architecture**](https://ruslanlap.github.io/pagespeed-insights-mcp/developers/architecture/)
 
 > You can also view the raw markdown files in the `docs/` directory or run `mkdocs serve` locally.
+
+## 📝 Release Notes
+
+Current release: **v1.2.3**.
+
+### v1.2.3 — Google Antigravity support
+
+- Added a Google Antigravity MCP configuration guide for `~/.gemini/config/mcp_config.json`.
+- Added an Antigravity-ready example configuration in [`examples/antigravity-config.json`](./examples/antigravity-config.json).
+- Tightened release automation so important MCP client integration documentation can trigger a patch release when commits use scoped conventional commit messages such as `docs(antigravity): ...`, `docs(integration): ...`, or `docs(config): ...`.
+
+For the complete release history, see [`CHANGELOG.md`](./CHANGELOG.md).
 
 ## ✨ Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ruslanlap/pagespeed-insights-mcp",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ruslanlap/pagespeed-insights-mcp",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruslanlap/pagespeed-insights-mcp",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "MCP server for Google PageSpeed Insights & Chrome UX Report APIs — 16 tools to analyze, compare, and optimize web performance with Claude, Cursor, or any MCP-compatible AI client",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
### Motivation

- Ensure important client/integration documentation updates (examples, Antigravity, config) can trigger a patch release automatically and surface release notes in the README and changelog.

### Description

- Configure `@semantic-release/commit-analyzer` in `.releaserc.json` with `releaseRules` to treat `docs(...)` commits for scopes like `antigravity`, `integration`, `config`, and `examples` as `patch` releases.
- Add a `v1.2.3` entry to `CHANGELOG.md` documenting the Google Antigravity MCP configuration example and release note improvements.
- Add a `Release Notes` section in `README.md` that describes `v1.2.3`, links to the Antigravity example, and explains the tightened release automation.
- Bump package version from `1.2.2` to `1.2.3` in `package.json` and `package-lock.json`.

### Testing

- No automated tests were modified in this change and no test suite was executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1be442fe4c832ba315e7b5b0c179e1)