### PR TITLE
chore(ci): add dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,69 @@
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Group MCP SDK updates together
+      mcp-sdk:
+        patterns:
+          - "@modelcontextprotocol/*"
+      # Group TypeScript tooling updates
+      typescript:
+        patterns:
+          - "typescript"
+          - "@typescript-eslint/*"
+          - "tsx"
+      # Group testing tools
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "nock"
+          - "@types/supertest"
+      # Group linting/formatting tools
+      linting:
+        patterns:
+          - "eslint"
+          - "prettier"
+      # Group semantic-release tooling
+      release:
+        patterns:
+          - "semantic-release"
+          - "@semantic-release/*"
+      # Group type definitions
+      types:
+        patterns:
+          - "@types/*"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"
+
+  # Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    labels:
+      - "docker"
+    commit-message:
+      prefix: "chore(docker)"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable automated dependency updates, based on the cavemenko-draft config with enhancements for this project's dependency structure.

## Configuration

### 3 ecosystems monitored (weekly, Monday):

| Ecosystem | Limit | Labels | Prefix |
|-----------|-------|--------|--------|
| **npm** | 10 PRs | `dependencies` | `chore(deps)` |
| **github-actions** | 5 PRs | `ci` | `chore(ci)` |
| **docker** | 2 PRs | `docker` | `chore(docker)` |

### Grouped npm updates (reduces PR noise):

| Group | Packages |
|-------|----------|
| **mcp-sdk** | `@modelcontextprotocol/*` |
| **typescript** | `typescript`, `@typescript-eslint/*`, `tsx` |
| **testing** | `vitest`, `@vitest/*`, `nock`, `@types/supertest` |
| **linting** | `eslint`, `prettier` |
| **release** | `semantic-release`, `@semantic-release/*` |
| **types** | `@types/*` |

Grouped updates mean e.g. all `@types/*` packages bump in a single PR instead of 5 separate PRs.

## Why

- Keeps 7 npm dependencies + 17 devDependencies up to date automatically
- GitHub Actions versions stay current (prevents Node.js deprecation warnings)
- Docker base image gets security patches automatically
- Weekly cadence balances freshness vs. PR noise
- Grouping reduces PR spam — related packages update together
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/pagespeed-insights-mcp/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->