### PR TITLE
fix: add INP, TTFB, FCP metrics to crux_summary output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -874,9 +874,11 @@ export class PageSpeedInsightsServer {
     summary += `**Form Factor:** ${record.key.formFactor}\n\n`;
 
     const cwvMetrics = {
-      "largest_contentful_paint": "Largest Contentful Paint",
-      "first_input_delay": "First Input Delay", 
-      "cumulative_layout_shift": "Cumulative Layout Shift",
+        "largest_contentful_paint": "Largest Contentful Paint",
+        "interaction_to_next_paint": "Interaction to Next Paint",
+        "cumulative_layout_shift": "Cumulative Layout Shift",
+        "experimental_time_to_first_byte": "Time to First Byte",
+        "first_contentful_paint": "First Contentful Paint",
     };
 
     summary += `## Core Web Vitals (Real User Data)\n`;


### PR DESCRIPTION
## Problem
`crux_summary` tool's `formatCruxSummary()` function only mapped 3 metrics 
(LCP, FID, CLS) from the CrUX API response, even though the underlying 
`CruxRecord` type is a generic `Record<string, {...}>` that supports any 
CrUX metric field.

Additionally, `first_input_delay` (FID) is deprecated by Google since 
March 2024 and replaced by INP, so most origins no longer return this 
field — meaning the metric list was effectively silently reduced to just 
LCP + CLS in practice.

## Fix
Updated `cwvMetrics` mapping in `formatCruxSummary()` to include:
- `interaction_to_next_paint` (INP) — the current official Core Web Vital
- `first_contentful_paint` (FCP)
- `experimental_time_to_first_byte` (TTFB)

Kept LCP and CLS as-is.

## Testing
Verified locally against real URLs with sufficient CrUX traffic — 
INP now appears correctly in output.