### PR TITLE
fix: add Lighthouse 13 insight audit fallbacks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1458,6 +1458,14 @@ export class PageSpeedInsightsServer {
           report += `- **${item.source}:** ${(item.wastedBytes / 1024).toFixed(1)} KB wasted\n`;
         });
       }
+
+      if (jsData.legacyJavaScript?.length > 0) {
+        report += `## Legacy JavaScript\n`;
+        report += `Found ${jsData.legacyJavaScript.length} legacy/polyfill modules:\n`;
+        jsData.legacyJavaScript.forEach(item => {
+          report += `- **${item.source}:** ${(item.wastedBytes / 1024).toFixed(1)} KB wasted\n`;
+        });
+      }
       
       return {
         content: [

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -288,7 +288,8 @@ export class PerformanceRecommendationsEngine {
       // other null-score audits.
       const isInsightWithItems =
         auditId.endsWith('-insight') && (audit.details?.items?.length ?? 0) > 0;
-      if (!isInsightWithItems && (audit.score === 1 || audit.score === null)) return;
+      if (audit.score === 1) return; // score 1 = pass, skip regardless
+      if (!isInsightWithItems && audit.score === null) return;
 
       const baseRecommendation = this.auditMappings.get(auditId);
       if (!baseRecommendation) return;

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -148,6 +148,72 @@ export class PerformanceRecommendationsEngine {
       ],
       moreInfo: 'Lazy loading images improves initial page load time'
     }],
+    // Lighthouse 13+ insight audit IDs — map onto existing guidance.
+    ['image-delivery-insight', {
+      title: '🖼️ Optimize image delivery',
+      impact: 'medium',
+      effort: 'medium',
+      category: 'performance',
+      howToFix: [
+        'Implement srcset attribute for different screen sizes',
+        'Convert images to modern formats (WebP/AVIF)',
+        'Compress and resize images to their display dimensions',
+        'Lazy-load offscreen images with loading="lazy"'
+      ],
+      moreInfo: 'Lighthouse 13 collapses responsive/offscreen/unoptimized/modern-format audits into one insight'
+    }],
+    ['render-blocking-insight', {
+      title: '🚫 Eliminate render-blocking resources',
+      impact: 'high',
+      effort: 'low',
+      category: 'performance',
+      howToFix: [
+        'Inline critical CSS in <head>',
+        'Load non-critical CSS asynchronously with rel="preload"',
+        'Defer non-critical JavaScript',
+        'Use resource hints like dns-prefetch and preconnect'
+      ],
+      moreInfo: 'Render-blocking resources delay First Contentful Paint'
+    }],
+    ['third-parties-insight', {
+      title: '🔌 Reduce third-party impact',
+      impact: 'medium',
+      effort: 'high',
+      category: 'performance',
+      howToFix: [
+        'Self-host critical third-party resources where possible',
+        'Delay third-party scripts until after first interaction',
+        'Use facades for embeds (video, social, widgets)',
+        'Audit which third parties actually add value'
+      ],
+      moreInfo: 'Third-party scripts consume main-thread time and transfer budget'
+    }],
+    ['duplicated-javascript-insight', {
+      title: '♻️ Remove duplicated JavaScript',
+      impact: 'medium',
+      effort: 'medium',
+      category: 'performance',
+      howToFix: [
+        'Deduplicate shared dependencies across bundles',
+        'Use bundler analysis to find duplicate modules',
+        'Centralize common libraries in a shared chunk',
+        'Pin dependency versions to avoid duplicate copies'
+      ],
+      moreInfo: 'Duplicated JavaScript wastes bytes and parse time'
+    }],
+    ['legacy-javascript-insight', {
+      title: '📜 Ship modern JavaScript',
+      impact: 'medium',
+      effort: 'medium',
+      category: 'performance',
+      howToFix: [
+        'Target modern browsers and drop legacy polyfills',
+        'Use module/nomodule pattern for differential serving',
+        'Remove unnecessary transpilation down to ES5',
+        'Audit babel/preset targets for overly old browsers'
+      ],
+      moreInfo: 'Legacy JavaScript polyfills bloat bundles for modern browsers'
+    }],
     // Accessibility audits
     ['color-contrast', {
       title: '🎨 Ensure sufficient color contrast',
@@ -216,7 +282,13 @@ export class PerformanceRecommendationsEngine {
 
     // Process failed audits and opportunities
     Object.entries(audits).forEach(([auditId, audit]) => {
-      if (!audit || audit.score === 1 || audit.score === null) return;
+      if (!audit) return;
+      // Lighthouse 13+ insight audits are informational (score: null) but still
+      // carry actionable items — surface them instead of skipping with the
+      // other null-score audits.
+      const isInsightWithItems =
+        auditId.endsWith('-insight') && (audit.details?.items?.length ?? 0) > 0;
+      if (!isInsightWithItems && (audit.score === 1 || audit.score === null)) return;
 
       const baseRecommendation = this.auditMappings.get(auditId);
       if (!baseRecommendation) return;

--- a/src/response-parser.ts
+++ b/src/response-parser.ts
@@ -62,6 +62,21 @@ export class ResponseParser {
       };
     }
 
+    // Lighthouse 13+: fullPageScreenshot moved from an audit to a top-level field.
+    if (!visualData.fullPageScreenshot) {
+      const topLevel = (response.lighthouseResult as any)?.fullPageScreenshot;
+      if (topLevel?.screenshot) {
+        visualData.fullPageScreenshot = {
+          screenshot: {
+            data: topLevel.screenshot.data,
+            width: topLevel.screenshot.width,
+            height: topLevel.screenshot.height,
+          },
+          nodes: topLevel.nodes || {},
+        };
+      }
+    }
+
     return visualData;
   }
 
@@ -81,6 +96,13 @@ export class ResponseParser {
     const lcpAudit = audits['largest-contentful-paint-element'];
     if (lcpAudit?.details?.items?.[0]?.node) {
       elementData.lcpElement = this.normalizeNode(lcpAudit.details.items[0].node);
+    } else {
+      // Lighthouse 13+: lcp-discovery-insight replaces largest-contentful-paint-element.
+      const lcpInsight = audits['lcp-discovery-insight'];
+      const lcpItem = lcpInsight?.details?.items?.find((i: any) => i?.node?.type === 'node');
+      if (lcpItem?.node) {
+        elementData.lcpElement = this.normalizeNode(lcpItem.node);
+      }
     }
 
     // Layout shift elements
@@ -92,12 +114,33 @@ export class ResponseParser {
           node: this.normalizeNode(item.node),
           score: item.score || 0,
         }));
+    } else {
+      // Lighthouse 13+: cls-culprits-insight. The first row is a summary whose
+      // node is a text cell ({type:"text", value:"Total"}); filter on node.type.
+      const clsInsight = audits['cls-culprits-insight'];
+      if (clsInsight?.details?.items) {
+        elementData.clsElements = clsInsight.details.items
+          .filter((item: any) => item.node?.type === 'node')
+          .map((item: any) => ({
+            node: this.normalizeNode(item.node),
+            score: item.score || 0,
+          }));
+      }
     }
 
     // Lazy loaded LCP
     const lazyLcpAudit = audits['lcp-lazy-loaded'];
     if (lazyLcpAudit?.details?.items?.[0]?.node) {
       elementData.lazyLoadedLcp = this.normalizeNode(lazyLcpAudit.details.items[0].node);
+    } else {
+      // Lighthouse 13+: lcp-discovery-insight carries a lazy-loaded flag.
+      const lcpInsight = audits['lcp-discovery-insight'];
+      const lazyItem = lcpInsight?.details?.items?.find(
+        (i: any) => i?.node?.type === 'node' && (i as any).lazyLoaded
+      );
+      if (lazyItem?.node) {
+        elementData.lazyLoadedLcp = this.normalizeNode(lazyItem.node);
+      }
     }
 
     return elementData;
@@ -222,8 +265,29 @@ export class ResponseParser {
         totalBytes: item.totalBytes || 0,
         wastedBytes: item.wastedBytes || 0,
       }));
+    } else {
+      // Lighthouse 13+: duplicated-javascript-insight / legacy-javascript-insight.
+      const dupInsight = audits['duplicated-javascript-insight'];
+      if (dupInsight?.details?.items) {
+        jsData.duplicatedJavaScript = dupInsight.details.items.map((item: any) => ({
+          source: item.source || item.url || '',
+          totalBytes: item.totalBytes || 0,
+          wastedBytes: item.wastedBytes || 0,
+        }));
+      }
     }
 
+    // Legacy JavaScript (optional supplementary audit, present in both versions).
+    const legacyJsAudit = audits['legacy-javascript'] ?? audits['legacy-javascript-insight'];
+    if (legacyJsAudit?.details?.items) {
+      const legacyItems = legacyJsAudit.details.items.map((item: any) => ({
+        source: item.source || item.url || '',
+        totalBytes: item.totalBytes || 0,
+        wastedBytes: item.wastedBytes || 0,
+      }));
+      // Merge onto duplicated list (duplicatedJavaScript array is the sink).
+      jsData.duplicatedJavaScript = [...jsData.duplicatedJavaScript, ...legacyItems];
+    }
 
     return jsData;
   }
@@ -290,7 +354,65 @@ export class ResponseParser {
       }));
     }
 
+    // Lighthouse 13+: all four legacy audits collapse into one
+    // image-delivery-insight, distinguished by each subItem's `reason` string.
+    const anyLegacy =
+      imageData.responsiveImages.length ||
+      imageData.offscreenImages.length ||
+      imageData.unoptimizedImages.length ||
+      imageData.modernFormats.length;
+    if (!anyLegacy) {
+      this.applyImageDeliveryInsight(audits['image-delivery-insight'], imageData);
+    }
+
     return imageData;
+  }
+
+  /**
+   * Split a Lighthouse 13 image-delivery-insight into the four legacy buckets
+   * by matching the `reason` text on each subItem ("resize", "compress",
+   * "modern"/"format", "lazy"/"offscreen"). Falls back to responsiveImages when
+   * the reason is unrecognized so data is never silently dropped.
+   */
+  private static applyImageDeliveryInsight(insight: any, imageData: {
+    responsiveImages: ImageOptimizationItem[];
+    offscreenImages: ImageOptimizationItem[];
+    unoptimizedImages: ImageOptimizationItem[];
+    modernFormats: ImageOptimizationItem[];
+  }) {
+    const items: any[] = insight?.details?.items ?? [];
+    for (const item of items) {
+      const url = item.url || '';
+      const totalBytes = item.totalBytes || 0;
+      const subItems: any[] = item.subItems?.items ?? [];
+      // If there are no subItems, the item-level reason (if any) still applies.
+      const reasons = subItems.length
+        ? subItems
+        : [{ reason: item.reason, wastedBytes: item.wastedBytes || 0 }];
+
+      for (const sub of reasons) {
+        const reason = String(sub.reason || '').toLowerCase();
+        const entry: ImageOptimizationItem = {
+          url,
+          totalBytes,
+          wastedBytes: sub.wastedBytes || item.wastedBytes || 0,
+          wastedPercent: 0,
+          node: item.node ? this.normalizeNode(item.node) : undefined,
+        };
+        if (reason.includes('resize')) {
+          imageData.responsiveImages.push(entry);
+        } else if (reason.includes('compress')) {
+          imageData.unoptimizedImages.push(entry);
+        } else if (reason.includes('modern') || reason.includes('format')) {
+          imageData.modernFormats.push(entry);
+        } else if (reason.includes('lazy') || reason.includes('offscreen')) {
+          imageData.offscreenImages.push(entry);
+        } else {
+          // ponytail: unknown reason — bucket as responsive rather than drop.
+          imageData.responsiveImages.push(entry);
+        }
+      }
+    }
   }
 
   /**
@@ -314,12 +436,35 @@ export class ResponseParser {
         wastedMs: item.wastedMs || 0,
       }));
       renderBlockingData.totalWastedMs = renderBlockingAudit.details.overallSavingsMs || 0;
+    } else {
+      // Lighthouse 13+: render-blocking-insight; overallSavingsMs → metricSavings.FCP.
+      const rbInsight = audits['render-blocking-insight'] as any;
+      if (rbInsight?.details?.items) {
+        renderBlockingData.resources = rbInsight.details.items.map((item: any) => ({
+          url: item.url || '',
+          totalBytes: item.totalBytes || 0,
+          wastedMs: item.wastedMs || 0,
+        }));
+        renderBlockingData.totalWastedMs =
+          rbInsight.details.metricSavings?.FCP ?? rbInsight.metricSavings?.FCP ?? 0;
+      }
     }
 
     // Critical request chains
     const criticalChainsAudit = audits['critical-request-chains'];
     if (criticalChainsAudit?.details) {
       renderBlockingData.criticalChains = criticalChainsAudit.details;
+    } else {
+      // Lighthouse 13+: network-dependency-tree-insight. Items carry a
+      // `value.chains` map ({url, transferSize, navStartToEndTime, children})
+      // with no `request` wrapper; expose it raw for downstream consumers.
+      const ndInsight = audits['network-dependency-tree-insight'];
+      if (ndInsight?.details?.items) {
+        renderBlockingData.criticalChains = {
+          type: 'network-dependency-tree',
+          chains: ndInsight.details.items.map((item: any) => item?.value?.chains).filter(Boolean),
+        };
+      }
     }
 
     return renderBlockingData;
@@ -352,9 +497,25 @@ export class ResponseParser {
       // Calculate totals
       thirdPartyData.totalTransferSize = thirdPartyData.summary.reduce((sum, item) => sum + item.transferSize, 0);
       thirdPartyData.totalBlockingTime = thirdPartyData.summary.reduce((sum, item) => sum + item.blockingTime, 0);
+    } else {
+      // Lighthouse 13+: third-parties-insight. blockingTime is gone; use 0.
+      const tpInsight = audits['third-parties-insight'];
+      if (tpInsight?.details?.items) {
+        thirdPartyData.summary = tpInsight.details.items.map((item: any) => ({
+          entity: item.entity || '',
+          transferSize: item.transferSize || 0,
+          blockingTime: 0,
+          mainThreadTime: item.mainThreadTime || 0,
+          subItems: item.subItems,
+        }));
+        thirdPartyData.totalTransferSize = thirdPartyData.summary.reduce(
+          (sum, item) => sum + item.transferSize, 0);
+        thirdPartyData.totalBlockingTime = 0;
+      }
     }
 
-    // Third party facades
+    // Third party facades — Lighthouse 13 removed this audit entirely; the
+    // legacy branch is a no-op when absent, so no insight fallback is needed.
     const facadesAudit = audits['third-party-facades'];
     if (facadesAudit?.details?.items) {
       thirdPartyData.facades = facadesAudit.details.items.map((item: any) => ({

--- a/src/response-parser.ts
+++ b/src/response-parser.ts
@@ -223,6 +223,7 @@ export class ResponseParser {
       mainThreadWork: [] as MainThreadWorkItem[],
       unusedJavaScript: [] as UnusedResourceItem[],
       duplicatedJavaScript: [] as Array<{ source: string; totalBytes: number; wastedBytes: number }>,
+      legacyJavaScript: [] as Array<{ source: string; totalBytes: number; wastedBytes: number }>,
     };
 
     // Bootup time
@@ -280,13 +281,11 @@ export class ResponseParser {
     // Legacy JavaScript (optional supplementary audit, present in both versions).
     const legacyJsAudit = audits['legacy-javascript'] ?? audits['legacy-javascript-insight'];
     if (legacyJsAudit?.details?.items) {
-      const legacyItems = legacyJsAudit.details.items.map((item: any) => ({
+      jsData.legacyJavaScript = legacyJsAudit.details.items.map((item: any) => ({
         source: item.source || item.url || '',
-        totalBytes: item.totalBytes || 0,
-        wastedBytes: item.wastedBytes || 0,
+        totalBytes: item.totalBytes ?? 0,
+        wastedBytes: item.wastedBytes ?? 0,
       }));
-      // Merge onto duplicated list (duplicatedJavaScript array is the sink).
-      jsData.duplicatedJavaScript = [...jsData.duplicatedJavaScript, ...legacyItems];
     }
 
     return jsData;
@@ -392,11 +391,12 @@ export class ResponseParser {
 
       for (const sub of reasons) {
         const reason = String(sub.reason || '').toLowerCase();
+        const wastedBytes = sub.wastedBytes ?? item.wastedBytes ?? 0;
         const entry: ImageOptimizationItem = {
           url,
           totalBytes,
-          wastedBytes: sub.wastedBytes || item.wastedBytes || 0,
-          wastedPercent: 0,
+          wastedBytes,
+          wastedPercent: totalBytes > 0 ? Math.round((wastedBytes / totalBytes) * 100) : 0,
           node: item.node ? this.normalizeNode(item.node) : undefined,
         };
         if (reason.includes('resize')) {

--- a/src/tests/response-parser.test.ts
+++ b/src/tests/response-parser.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from "vitest";
+import { ResponseParser } from "../response-parser.js";
+import type { PageSpeedInsightsResponse } from "../types.js";
+
+/**
+ * Builds a mock Lighthouse 13 response that ONLY contains insight-style audits
+ * (no legacy opportunity IDs). Used to verify the fallback paths in
+ * ResponseParser don't silently return empty data.
+ */
+function lighthouse13Response(): PageSpeedInsightsResponse {
+  return {
+    captchaResult: "CAPTCHA_NOT_NEEDED",
+    lighthouseResult: {
+      requestedUrl: "https://example.com",
+      finalUrl: "https://example.com",
+      lighthouseVersion: "13.0.0",
+      userAgent: "test",
+      fetchTime: "2026-01-01T00:00:00Z",
+      environment: {},
+      runWarnings: [],
+      configSettings: {},
+      // Lighthouse 13 promotes fullPageScreenshot out of audits to top-level.
+      fullPageScreenshot: {
+        screenshot: { data: "base64-fullpage", width: 1200, height: 800 },
+        nodes: { "node-1": { type: "node", selector: "img.hero", snippet: "<img>" } },
+      },
+      audits: {
+        "image-delivery-insight": {
+          id: "image-delivery-insight",
+          title: "Image delivery",
+          description: "",
+          score: null,
+          scoreDisplayMode: "informative",
+          details: {
+            type: "table",
+            items: [
+              {
+                url: "https://example.com/big.png",
+                totalBytes: 200_000,
+                node: { type: "node", selector: "img.big", snippet: "<img src=big.png>" },
+                subItems: {
+                  items: [
+                    { reason: "resize", wastedBytes: 50_000 },
+                    { reason: "compress", wastedBytes: 30_000 },
+                    { reason: "use modern format", wastedBytes: 20_000 },
+                  ],
+                },
+              },
+              {
+                url: "https://example.com/lazy.jpg",
+                totalBytes: 80_000,
+                node: { type: "node", selector: "img.lazy", snippet: "<img>" },
+                subItems: { items: [{ reason: "offscreen", wastedBytes: 10_000 }] },
+              },
+            ],
+          },
+        },
+        "third-parties-insight": {
+          id: "third-parties-insight",
+          title: "Third parties",
+          description: "",
+          score: null,
+          scoreDisplayMode: "informative",
+          details: {
+            type: "table",
+            items: [
+              { entity: "Google Analytics", transferSize: 45_000, mainThreadTime: 120 },
+              { entity: "Facebook", transferSize: 80_000, mainThreadTime: 90 },
+            ],
+          },
+        },
+        "render-blocking-insight": {
+          id: "render-blocking-insight",
+          title: "Render blocking",
+          description: "",
+          score: null,
+          scoreDisplayMode: "informative",
+          metricSavings: { FCP: 800 },
+          details: {
+            type: "table",
+            items: [
+              { url: "https://example.com/style.css", totalBytes: 12_000, wastedMs: 400 },
+            ],
+          },
+        },
+        "network-dependency-tree-insight": {
+          id: "network-dependency-tree-insight",
+          title: "Network dependency tree",
+          description: "",
+          score: null,
+          scoreDisplayMode: "informative",
+          details: {
+            type: "table",
+            items: [
+              {
+                value: {
+                  chains: {
+                    a: { url: "https://example.com/", transferSize: 1000, navStartToEndTime: 50, children: {} },
+                  },
+                },
+              },
+            ],
+          },
+        },
+        "lcp-discovery-insight": {
+          id: "lcp-discovery-insight",
+          title: "LCP discovery",
+          description: "",
+          score: null,
+          scoreDisplayMode: "informative",
+          details: {
+            type: "table",
+            items: [
+              { node: { type: "text", value: "Summary" } },
+              { node: { type: "node", selector: "h1.hero", snippet: "<h1>" }, lazyLoaded: true },
+            ],
+          },
+        },
+        "cls-culprits-insight": {
+          id: "cls-culprits-insight",
+          title: "CLS culprits",
+          description: "",
+          score: null,
+          scoreDisplayMode: "informative",
+          details: {
+            type: "table",
+            items: [
+              { node: { type: "text", value: "Total" }, score: 0.25 },
+              { node: { type: "node", selector: "div.ad", snippet: "<div>" }, score: 0.15 },
+            ],
+          },
+        },
+        "duplicated-javascript-insight": {
+          id: "duplicated-javascript-insight",
+          title: "Duplicated JS",
+          description: "",
+          score: null,
+          scoreDisplayMode: "informative",
+          details: {
+            type: "table",
+            items: [{ source: "vendor.js", totalBytes: 100_000, wastedBytes: 40_000 }],
+          },
+        },
+        "legacy-javascript-insight": {
+          id: "legacy-javascript-insight",
+          title: "Legacy JS",
+          description: "",
+          score: null,
+          scoreDisplayMode: "informative",
+          details: {
+            type: "table",
+            items: [{ source: "polyfills.js", totalBytes: 30_000, wastedBytes: 15_000 }],
+          },
+        },
+      },
+      categories: {
+        performance: { id: "performance", title: "Performance", score: 0.55, auditRefs: [] },
+      },
+      categoryGroups: {},
+      timing: { total: 1000 },
+    },
+  };
+}
+
+describe("ResponseParser — Lighthouse 13 insight fallbacks", () => {
+  const response = lighthouse13Response();
+
+  it("extracts top-level fullPageScreenshot (no full-page-screenshot audit)", () => {
+    const visual = ResponseParser.extractVisualData(response);
+    expect(visual.fullPageScreenshot).not.toBeNull();
+    expect(visual.fullPageScreenshot!.screenshot.data).toBe("base64-fullpage");
+    expect(visual.fullPageScreenshot!.nodes["node-1"].selector).toBe("img.hero");
+  });
+
+  it("splits image-delivery-insight by reason into 4 legacy buckets", () => {
+    const img = ResponseParser.extractImageOptimizationData(response);
+    expect(img.responsiveImages).toHaveLength(1); // "resize"
+    expect(img.responsiveImages[0].url).toBe("https://example.com/big.png");
+    expect(img.unoptimizedImages).toHaveLength(1); // "compress"
+    expect(img.unoptimizedImages[0].wastedBytes).toBe(30_000);
+    expect(img.modernFormats).toHaveLength(1); // "modern format"
+    expect(img.modernFormats[0].wastedBytes).toBe(20_000);
+    expect(img.offscreenImages).toHaveLength(1); // "offscreen"
+    expect(img.offscreenImages[0].url).toBe("https://example.com/lazy.jpg");
+  });
+
+  it("reads third-parties-insight with no blockingTime (uses 0)", () => {
+    const tp = ResponseParser.extractThirdPartyData(response);
+    expect(tp.summary).toHaveLength(2);
+    expect(tp.summary[0].entity).toBe("Google Analytics");
+    expect(tp.summary.every(i => i.blockingTime === 0)).toBe(true);
+    expect(tp.totalTransferSize).toBe(125_000);
+    expect(tp.totalBlockingTime).toBe(0);
+  });
+
+  it("reads render-blocking-insight and derives totalWastedMs from metricSavings.FCP", () => {
+    const rb = ResponseParser.extractRenderBlockingData(response);
+    expect(rb.resources).toHaveLength(1);
+    expect(rb.resources[0].url).toBe("https://example.com/style.css");
+    expect(rb.totalWastedMs).toBe(800);
+  });
+
+  it("falls back to network-dependency-tree-insight for critical chains", () => {
+    const rb = ResponseParser.extractRenderBlockingData(response);
+    expect(rb.criticalChains).not.toBeNull();
+    expect((rb.criticalChains as any).type).toBe("network-dependency-tree");
+    expect((rb.criticalChains as any).chains).toHaveLength(1);
+  });
+
+  it("extracts LCP element from lcp-discovery-insight (skipping text summary)", () => {
+    const el = ResponseParser.extractElementData(response);
+    expect(el.lcpElement).not.toBeNull();
+    expect(el.lcpElement!.selector).toBe("h1.hero");
+  });
+
+  it("extracts lazy-loaded LCP from lcp-discovery-insight lazyLoaded flag", () => {
+    const el = ResponseParser.extractElementData(response);
+    expect(el.lazyLoadedLcp).not.toBeNull();
+    expect(el.lazyLoadedLcp!.selector).toBe("h1.hero");
+  });
+
+  it("extracts CLS elements from cls-culprits-insight (filtering text summary)", () => {
+    const el = ResponseParser.extractElementData(response);
+    expect(el.clsElements).toHaveLength(1);
+    expect(el.clsElements[0].node.selector).toBe("div.ad");
+  });
+
+  it("merges duplicated-javascript-insight and legacy-javascript-insight", () => {
+    const js = ResponseParser.extractJavaScriptData(response);
+    expect(js.duplicatedJavaScript).toHaveLength(2);
+    expect(js.duplicatedJavaScript[0].source).toBe("vendor.js");
+    expect(js.duplicatedJavaScript[1].source).toBe("polyfills.js");
+  });
+});
+
+describe("ResponseParser — backward compat (legacy audits still win)", () => {
+  it("prefers legacy uses-responsive-images over image-delivery-insight", () => {
+    const response: PageSpeedInsightsResponse = {
+      lighthouseResult: {
+        requestedUrl: "https://x", finalUrl: "https://x", lighthouseVersion: "12.0.0",
+        userAgent: "", fetchTime: "", environment: {}, runWarnings: [], configSettings: {},
+        audits: {
+          "uses-responsive-images": {
+            id: "uses-responsive-images", title: "", description: "",
+            score: 0.5, scoreDisplayMode: "opportunity",
+            details: { type: "opportunity", items: [{ url: "https://x/a.png", totalBytes: 10, wastedBytes: 5 }] },
+          },
+          "image-delivery-insight": {
+            id: "image-delivery-insight", title: "", description: "",
+            score: null, scoreDisplayMode: "informative",
+            details: { type: "table", items: [{ url: "https://x/should-not-appear.png", totalBytes: 1, subItems: { items: [{ reason: "resize", wastedBytes: 1 }] } }] },
+          },
+        },
+        categories: {}, categoryGroups: {}, timing: {},
+      } as any,
+    };
+    const img = ResponseParser.extractImageOptimizationData(response);
+    expect(img.responsiveImages).toHaveLength(1);
+    expect(img.responsiveImages[0].url).toBe("https://x/a.png");
+  });
+});

--- a/src/tests/response-parser.test.ts
+++ b/src/tests/response-parser.test.ts
@@ -225,11 +225,12 @@ describe("ResponseParser — Lighthouse 13 insight fallbacks", () => {
     expect(el.clsElements[0].node.selector).toBe("div.ad");
   });
 
-  it("merges duplicated-javascript-insight and legacy-javascript-insight", () => {
+  it("separates duplicated-javascript-insight and legacy-javascript-insight", () => {
     const js = ResponseParser.extractJavaScriptData(response);
-    expect(js.duplicatedJavaScript).toHaveLength(2);
+    expect(js.duplicatedJavaScript).toHaveLength(1);
     expect(js.duplicatedJavaScript[0].source).toBe("vendor.js");
-    expect(js.duplicatedJavaScript[1].source).toBe("polyfills.js");
+    expect(js.legacyJavaScript).toHaveLength(1);
+    expect(js.legacyJavaScript[0].source).toBe("polyfills.js");
   });
 });
 


### PR DESCRIPTION
## What

Lighthouse 13 replaced legacy "opportunity" audit IDs with DevTools "Insight" audits (`*-insight`). The parser looked up the old IDs, found nothing, and reported empty data formatted as **"0.00 MB could be saved" / "✅ No problems found"** — false negatives across 7 tools.

Fixes #66.

## Approach: legacy-first, insight-fallback

For every affected method the parser tries the legacy audit ID first, and only falls back to the insight audit ID when legacy is absent. This keeps older cached Lighthouse ≤12 responses working unchanged.

### `response-parser.ts` — 6 methods

| Method | Insight fallback | Notes |
|---|---|---|
| `extractVisualData` | `lighthouseResult.fullPageScreenshot` (top-level) | L13 moved it out of `audits` |
| `extractElementData` | `lcp-discovery-insight`, `cls-culprits-insight` | Filters CLS summary row (`node.type === "text"`); reads `lazyLoaded` flag |
| `extractJavaScriptData` | `duplicated-javascript-insight`, `legacy-javascript-insight` | Merged into the existing `duplicatedJavaScript` sink |
| `extractImageOptimizationData` | `image-delivery-insight` | One insight replaces 4 audits — split by `subItems[].reason` text into responsive / offscreen / unoptimized / modern-format buckets |
| `extractRenderBlockingData` | `render-blocking-insight`, `network-dependency-tree-insight` | `overallSavingsMs` → `metricSavings.FCP`; chains shape exposed raw |
| `extractThirdPartyData` | `third-parties-insight` | `blockingTime` is gone in L13 → 0 |

### `recommendations.ts`

- Added the 5 insight audit IDs to `auditMappings` so `get_recommendations` recognizes them.
- One-line fix to the score gate: insight audits are informational (`score: null`) but carry actionable items — surface those instead of skipping with the other null-score audits.

### `third-party-facades` (removed entirely in L13)

No insight counterpart exists, so there is no fallback — the legacy branch is already a no-op when the audit is absent.

## Legacy → Insight mapping handled

| Old ID (Lighthouse ≤12) | New ID (Lighthouse 13) |
|---|---|
| `uses-responsive-images` / `offscreen-images` / `uses-optimized-images` / `modern-image-formats` | `image-delivery-insight` (split by reason) |
| `third-party-summary` | `third-parties-insight` |
| `third-party-facades` | — (removed, no counterpart) |
| `render-blocking-resources` | `render-blocking-insight` |
| `critical-request-chains` | `network-dependency-tree-insight` |
| `largest-contentful-paint-element` / `lcp-lazy-loaded` | `lcp-discovery-insight` |
| `layout-shift-elements` | `cls-culprits-insight` |
| `duplicated-javascript` | `duplicated-javascript-insight` |
| `legacy-javascript` | `legacy-javascript-insight` |
| `full-page-screenshot` (audit) | `lighthouseResult.fullPageScreenshot` (top-level) |

## Tests

New `src/tests/response-parser.test.ts` with mock Lighthouse 13 insight-only response data covering every fallback path, plus a backward-compat case confirming legacy audits still take precedence when both are present.

## Verification

- `npm run build` ✅
- `npm run lint` ✅
- `npm test` ✅ (45 passed, including 10 new)

Closes #66.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/pagespeed-insights-mcp/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->