### PR TITLE
refactor: extract shared cruxPost helper with retry

### DIFF
--- a/src/pagespeed-client.ts
+++ b/src/pagespeed-client.ts
@@ -170,113 +170,91 @@ export class PageSpeedClient {
     });
   }
 
+  // Shared CrUX POST with retry — ponytail: one helper for both CrUX methods,
+  // add per-method knobs only if they ever diverge.
+  private async cruxPost(body: Record<string, unknown>, correlationId: string, label: string): Promise<any> {
+    const logger = createRequestLogger(correlationId, label);
+    return this.limiter(async () => {
+      const url = `https://chromeuxreport.googleapis.com/v1/records:queryRecord?key=${this.apiKey}`;
+      return pRetry(
+        async () => {
+          const controller = new AbortController();
+          const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+          try {
+            const response = await fetch(url, {
+              method: "POST",
+              headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
+              body: JSON.stringify(body),
+              signal: controller.signal,
+            });
+            clearTimeout(timeoutId);
+            if (!response.ok) {
+              const errorText = await response.text();
+              const error = new Error(`CrUX API error: ${response.status} ${response.statusText} - ${errorText}`);
+              if (response.status >= 400 && response.status < 500) error.name = "ClientError";
+              throw error;
+            }
+            return response.json();
+          } catch (error) {
+            clearTimeout(timeoutId);
+            const msg = error instanceof Error ? error.message : "Unknown error";
+            logger.warn({ error: this.redact(msg) }, `${label} failed`);
+            throw error;
+          }
+        },
+        {
+          retries: this.retryAttempts,
+          onFailedAttempt: (error) => { if (error.name === "ClientError") throw error; },
+          factor: 2, minTimeout: 1000, maxTimeout: 10000,
+        }
+      );
+    });
+  }
+
   async getCruxData(input: CruxSummaryInput, correlationId: string): Promise<any> {
-    const logger = createRequestLogger(correlationId, "crux-summary");
-    
+    const logger = createRequestLogger("crux", "crux-summary");
+
     return this.limiter(async () => {
       const cacheKey = createCruxCacheKey(input.url, input.formFactor);
-      
+
       const cached = cache.get(cacheKey);
       if (cached) {
-        logger.debug("Cache hit for CrUX request");
+        logger.debug("Cache hit for crux-summary");
         return cached;
       }
-      
-      logger.info({ url: input.url }, "Fetching CrUX data");
-      
+
+      logger.info({url: input.url}, "Fetching crux-summary");
+
       const requestBody = {
         url: input.url,
         ...(input.formFactor && { formFactor: input.formFactor }),
       };
-      
-      const url = `https://chromeuxreport.googleapis.com/v1/records:queryRecord?key=${this.apiKey}`;
-      
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), this.timeout);
-      
-      try {
-        const response = await fetch(url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "User-Agent": USER_AGENT,
-          },
-          body: JSON.stringify(requestBody),
-          signal: controller.signal,
-        });
-        
-        clearTimeout(timeoutId);
-        
-        if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error(`CrUX API error: ${response.status} ${response.statusText} - ${errorText}`);
-        }
-        
-        const data = await response.json();
-        cache.set(cacheKey, data, this.cacheTTL);
-        
-        logger.info({ url: input.url }, "CrUX request successful");
-        return data;
-      } catch (error) {
-        clearTimeout(timeoutId);
-        const errorMessage = error instanceof Error ? error.message : "Unknown error";
-        logger.warn({ error: this.redact(errorMessage) }, "CrUX request failed");
-        throw error;
-      }
+      const data = await this.cruxPost(requestBody, "crux", "crux-summary");
+      cache.set(cacheKey, data, this.cacheTTL);
+      logger.info({url: input.url}, "CrUX request successful");
+      return data;
     });
   }
 
   async getOriginCruxData(input: OriginCruxInput, correlationId: string): Promise<any> {
-    const logger = createRequestLogger(correlationId, "origin-crux");
+    const logger = createRequestLogger("crux", "origin-crux");
 
     return this.limiter(async () => {
       const cacheKey = createCruxCacheKey(input.origin, input.formFactor || "ALL");
 
       const cached = cache.get(cacheKey);
       if (cached) {
-        logger.debug("Cache hit for origin CrUX request");
+        logger.debug("Cache hit for origin-crux");
         return cached;
       }
 
-      logger.info({ origin: input.origin }, "Fetching origin CrUX data");
+      logger.info({origin: input.origin}, "Fetching origin-crux");
 
-      const requestBody: Record<string, unknown> = { origin: input.origin };
-      if (input.formFactor) requestBody.formFactor = input.formFactor;
-
-      const url = `https://chromeuxreport.googleapis.com/v1/records:queryRecord?key=${this.apiKey}`;
-
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), this.timeout);
-
-      try {
-        const response = await fetch(url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "User-Agent": USER_AGENT,
-          },
-          body: JSON.stringify(requestBody),
-          signal: controller.signal,
-        });
-
-        clearTimeout(timeoutId);
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error(`CrUX API error: ${response.status} ${response.statusText} - ${errorText}`);
-        }
-
-        const data = await response.json();
-        cache.set(cacheKey, data, this.cacheTTL);
-
-        logger.info({ origin: input.origin }, "Origin CrUX request successful");
-        return data;
-      } catch (error) {
-        clearTimeout(timeoutId);
-        const errorMessage = error instanceof Error ? error.message : "Unknown error";
-        logger.warn({ error: this.redact(errorMessage) }, "Origin CrUX request failed");
-        throw error;
-      }
+      const requestBody = { origin: input.origin, ...(input.formFactor && { formFactor: input.formFactor }) } as Record<string, unknown>;
+      const data = await this.cruxPost(requestBody, "crux", "origin-crux");
+      cache.set(cacheKey, data, this.cacheTTL);
+      logger.info({origin: input.origin}, "Origin CrUX request successful");
+      return data;
     });
   }
 }

--- a/src/pagespeed-client.ts
+++ b/src/pagespeed-client.ts
@@ -171,7 +171,8 @@ export class PageSpeedClient {
   }
 
   // Shared CrUX POST with retry — ponytail: one helper for both CrUX methods,
-  // add per-method knobs only if they ever diverge.
+  // add per-method knobs only if they ever diverge. Limiter acquired HERE only;
+  // callers must not wrap in this.limiter (nested acquisition deadlocks at limit 1).
   private async cruxPost(body: Record<string, unknown>, correlationId: string, label: string): Promise<any> {
     const logger = createRequestLogger(correlationId, label);
     return this.limiter(async () => {
@@ -194,7 +195,7 @@ export class PageSpeedClient {
               if (response.status >= 400 && response.status < 500) error.name = "ClientError";
               throw error;
             }
-            return response.json();
+            return await response.json();
           } catch (error) {
             clearTimeout(timeoutId);
             const msg = error instanceof Error ? error.message : "Unknown error";
@@ -211,50 +212,49 @@ export class PageSpeedClient {
     });
   }
 
+
   async getCruxData(input: CruxSummaryInput, correlationId: string): Promise<any> {
-    const logger = createRequestLogger("crux", "crux-summary");
+    const logger = createRequestLogger(correlationId, "crux-summary");
+    const cacheKey = createCruxCacheKey(input.url, input.formFactor);
 
-    return this.limiter(async () => {
-      const cacheKey = createCruxCacheKey(input.url, input.formFactor);
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      logger.debug("Cache hit for CrUX request");
+      return cached;
+    }
 
-      const cached = cache.get(cacheKey);
-      if (cached) {
-        logger.debug("Cache hit for crux-summary");
-        return cached;
-      }
+    logger.info({ url: input.url }, "Fetching CrUX data");
 
-      logger.info({url: input.url}, "Fetching crux-summary");
+    const requestBody = {
+      url: input.url,
+      ...(input.formFactor && { formFactor: input.formFactor }),
+    };
+    const data = await this.cruxPost(requestBody, correlationId, "crux-summary");
+    cache.set(cacheKey, data, this.cacheTTL);
 
-      const requestBody = {
-        url: input.url,
-        ...(input.formFactor && { formFactor: input.formFactor }),
-      };
-      const data = await this.cruxPost(requestBody, "crux", "crux-summary");
-      cache.set(cacheKey, data, this.cacheTTL);
-      logger.info({url: input.url}, "CrUX request successful");
-      return data;
-    });
+    logger.info({ url: input.url }, "CrUX request successful");
+    return data;
   }
 
   async getOriginCruxData(input: OriginCruxInput, correlationId: string): Promise<any> {
-    const logger = createRequestLogger("crux", "origin-crux");
+    const logger = createRequestLogger(correlationId, "origin-crux");
+    const cacheKey = createCruxCacheKey(input.origin, input.formFactor || "ALL");
 
-    return this.limiter(async () => {
-      const cacheKey = createCruxCacheKey(input.origin, input.formFactor || "ALL");
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      logger.debug("Cache hit for origin CrUX request");
+      return cached;
+    }
 
-      const cached = cache.get(cacheKey);
-      if (cached) {
-        logger.debug("Cache hit for origin-crux");
-        return cached;
-      }
+    logger.info({ origin: input.origin }, "Fetching origin CrUX data");
 
-      logger.info({origin: input.origin}, "Fetching origin-crux");
+    const requestBody: Record<string, unknown> = { origin: input.origin };
+    if (input.formFactor) requestBody.formFactor = input.formFactor;
 
-      const requestBody = { origin: input.origin, ...(input.formFactor && { formFactor: input.formFactor }) } as Record<string, unknown>;
-      const data = await this.cruxPost(requestBody, "crux", "origin-crux");
-      cache.set(cacheKey, data, this.cacheTTL);
-      logger.info({origin: input.origin}, "Origin CrUX request successful");
-      return data;
-    });
+    const data = await this.cruxPost(requestBody, correlationId, "origin-crux");
+    cache.set(cacheKey, data, this.cacheTTL);
+
+    logger.info({ origin: input.origin }, "Origin CrUX request successful");
+    return data;
   }
 }

--- a/src/tests/pagespeed-client.crux-retry.test.ts
+++ b/src/tests/pagespeed-client.crux-retry.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import nock from "nock";
+import { PageSpeedClient } from "../pagespeed-client.js";
+import { cache } from "../cache.js";
+
+vi.mock("../env.js", () => ({
+  getEnv: () => ({
+    GOOGLE_API_KEY: "test-api-key",
+    REQUEST_TIMEOUT: 30000,
+    RETRY_ATTEMPTS: 2,
+    CACHE_TTL: 3600,
+    MAX_CONCURRENCY: 3,
+    LOG_LEVEL: "info",
+    NODE_ENV: "test",
+  }),
+}));
+
+describe("PageSpeedClient CrUX retry", () => {
+  let client: PageSpeedClient;
+
+  beforeEach(() => {
+    client = new PageSpeedClient();
+    nock.cleanAll();
+    cache.clear();
+  });
+
+  it("retries transient 5xx and succeeds", async () => {
+    const mock = { record: { key: { formFactor: "PHONE" } } };
+    const scope = nock("https://chromeuxreport.googleapis.com")
+      .post("/v1/records:queryRecord")
+      .query(true)
+      .twice()
+      .reply(500, "server error")
+      .post("/v1/records:queryRecord")
+      .query(true)
+      .reply(200, mock);
+
+    const result = await client.getCruxData(
+      { url: "https://example.com" },
+      "corr-crux-retry"
+    );
+    expect(result).toEqual(mock);
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it("does not retry on 4xx", async () => {
+    const scope = nock("https://chromeuxreport.googleapis.com")
+      .post("/v1/records:queryRecord")
+      .query(true)
+      .once()
+      .reply(404, { error: { message: "no data" } });
+
+    await expect(
+      client.getCruxData({ url: "https://example.com" }, "corr-4xx")
+    ).rejects.toThrow(/CrUX API error: 404/);
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it("caches successful CrUX responses (single HTTP call)", async () => {
+    const mock = { record: { key: { formFactor: "PHONE" } } };
+    const scope = nock("https://chromeuxreport.googleapis.com")
+      .post("/v1/records:queryRecord")
+      .query(true)
+      .once()
+      .reply(200, mock);
+
+    await client.getOriginCruxData({ origin: "https://example.com" }, "c1");
+    await client.getOriginCruxData({ origin: "https://example.com" }, "c2");
+    expect(scope.isDone()).toBe(true); // second call served from cache
+  });
+});


### PR DESCRIPTION
## What
- Extracts a private `cruxPost()` helper used by both `getCruxData` and `getOriginCruxData` (~90% duplicated code removed)
- **Bug fix:** CrUX requests previously did a bare `fetch` — transient 5xx/network errors failed immediately, while PSI requests retried via `pRetry`. CrUX now retries with the same policy (4xx excluded).
- Cache logic, public signatures and behavior otherwise unchanged.

## Test plan
- [ ] CI matrix green (lint + typecheck + vitest on node 20/22/24)
- [ ] Existing `pagespeed-client.test.ts` covers error paths

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/pagespeed-insights-mcp/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->