### PR TITLE
docs: fix MCP Toplist badge ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PageSpeed Insights MCP Server
 
-[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fruslanlap%2Fpagespeed-insights-mcp.svg)](https://mcptoplist.com/server/glama%2Fruslanlap%2Fpagespeed-insights-mcp)
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.ruslanlap%2Fpagespeed-insights-mcp.svg)](https://mcptoplist.com/server/io.github.ruslanlap%2Fpagespeed-insights-mcp)
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/ruslanlap/pagespeed-insights-mcp/master/assets/1.png" alt="PageSpeed MCP chat demo" width="48%" />


### PR DESCRIPTION
Badge used the `glama/ruslanlap/pagespeed-insights-mcp` identifier, which renders as "not listed" even though the server **is tracked** (#3,021 of 108,151 — top 5%).

The correct registry identifier is `io.github.ruslanlap/pagespeed-insights-mcp` (Official MCP Registry name). Badge URL verified → HTTP 200.

Also worth noting: Toplist tracks only v1.5.2 while npm is at 1.7.0 — version sync to the official registry may need a re-publish/refresh.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/pagespeed-insights-mcp/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->