### PR TITLE
docs: conversion-focused README (quickstart up top, differentiation section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PageSpeed Insights MCP Server
 
-[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fruslanlap%2Fpagespeed-insights-mcp.svg)](https://mcptoplist.com/server/glama%2Fruslanlap%2Fpagespeed-insights-mcp)
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.ruslanlap%2Fpagespeed-insights-mcp.svg)](https://mcptoplist.com/server/io.github.ruslanlap%2Fpagespeed-insights-mcp)
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/ruslanlap/pagespeed-insights-mcp/master/assets/1.png" alt="PageSpeed MCP chat demo" width="48%" />

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Most PageSpeed MCP servers wrap **one** tool: "run PSI on a URL." This server sh
 - **Practical extras**: caching for repeat runs and smart recommendations tuned for AI agents to act on
 - **Battle-tested**: published on npm, listed in the [Official MCP Registry](https://registry.modelcontextprotocol.io/) and [Glama](https://glama.ai/mcp/servers), CI-tested with Vitest
 
-> **🎬 [View Interactive Demo →](https://ruslanlap.github.io/pagespeed-insights-mcp/demo/)** — See all 19 tools in action with animated examples
+> **🎬 [View Interactive Demo →](https://ruslanlap.github.io/pagespeed-insights-mcp/demo/)** — See the tools in action with animated examples
 > Fallback URL: [https://ruslanlap.github.io/pagespeed-insights-mcp/demo.html](https://ruslanlap.github.io/pagespeed-insights-mcp/demo.html)
 
 ## 📖 Table of Contents
@@ -107,7 +107,7 @@ Most PageSpeed MCP servers wrap **one** tool: "run PSI on a URL." This server sh
 
 ---
 
-## ⚙️ Client Configuration Examples
+## ⚙️ Client Configuration
 
 ### Claude Desktop
 
@@ -591,6 +591,7 @@ Run a full audit including accessibility, SEO, and best practices for https://ex
 | `crux_summary` | Real-world Core Web Vitals from Chrome UX Report (field data) |
 | `get_origin_crux` | Domain-level (origin) Chrome UX Report field data across all pages |
 | `compare_pages` | Side-by-side performance comparison between two URLs |
+| `compare_baseline` | Compare current run against a stored baseline to track regressions over time |
 
 ### Advanced Diagnostics
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # PageSpeed Insights MCP Server
 
+**19-tool MCP server** for Google PageSpeed Insights & Chrome UX Report APIs. Analyze, compare, and optimize web performance directly through Claude, Cursor, or any MCP-compatible AI client.
+
+## ⚡ Quick Start (Copy & Paste)
+
+```json
+{
+  "mcpServers": {
+    "pagespeed-insights": {
+      "command": "npx",
+      "args": ["-y", "pagespeed-insights-mcp"],
+      "env": { "GOOGLE_API_KEY": "your-google-api-key" }
+    }
+  }
+}
+```
+
+Get a free API key at [Google Cloud Console](https://developers.google.com/speed/docs/insights/v5/get-started) → paste into Claude Desktop's `claude_desktop_config.json` → restart. Done. ([Codex/OpenAI config](#codex--openai), [Docker](#option-3-docker))
+
+[![npm version](https://img.shields.io/npm/v/pagespeed-insights-mcp.svg)](https://www.npmjs.com/package/pagespeed-insights-mcp)
+[![npm downloads](https://img.shields.io/npm/dm/pagespeed-insights-mcp.svg)](https://www.npmjs.com/package/pagespeed-insights-mcp)
 [![MCP Toplist](https://mcptoplist.com/badge/io.github.ruslanlap%2Fpagespeed-insights-mcp.svg)](https://mcptoplist.com/server/io.github.ruslanlap%2Fpagespeed-insights-mcp)
 
 <p align="center">
@@ -7,17 +27,23 @@
   <img src="https://raw.githubusercontent.com/ruslanlap/pagespeed-insights-mcp/master/assets/2.png" alt="PageSpeed MCP terminal demo" width="48%" />
 </p>
 
-[![npm version](https://img.shields.io/npm/v/pagespeed-insights-mcp.svg)](https://www.npmjs.com/package/pagespeed-insights-mcp)
-[![npm downloads](https://img.shields.io/npm/dm/pagespeed-insights-mcp.svg)](https://www.npmjs.com/package/pagespeed-insights-mcp)
 [![GitHub Package Version](https://img.shields.io/github/package-json/v/ruslanlap/pagespeed-insights-mcp?label=github%20package)](https://github.com/ruslanlap/pagespeed-insights-mcp/pkgs/npm/pagespeed-insights-mcp)
 [![CI](https://github.com/ruslanlap/pagespeed-insights-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/ruslanlap/pagespeed-insights-mcp/actions/workflows/ci.yml)
 [![Documentation](https://img.shields.io/badge/docs-online-blue.svg)](https://ruslanlap.github.io/pagespeed-insights-mcp/)
 [![Live Demo](https://img.shields.io/badge/demo-live-blueviolet.svg)](https://ruslanlap.github.io/pagespeed-insights-mcp/demo/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**18-tool MCP server** for Google PageSpeed Insights & Chrome UX Report APIs. Analyze, compare, and optimize web performance directly through Claude, Cursor, or any MCP-compatible AI client.
+## 🔥 What Makes It Different
 
-> **🎬 [View Interactive Demo →](https://ruslanlap.github.io/pagespeed-insights-mcp/demo/)** — See all 18 tools in action with animated examples
+Most PageSpeed MCP servers wrap **one** tool: "run PSI on a URL." This server ships **19 tools** covering the full performance workflow — not just a score, but an action plan:
+
+- **Full toolkit**: page analysis, CrUX real-user data (URL + origin), Lighthouse audits, multi-page & batch comparison, baselines, and regression tracking
+- **Deep diagnostics**: element-level, network, JavaScript, image optimization, render-blocking, and third-party impact analysis
+- **Actionable output**: a recommendations engine that turns raw Lighthouse data into prioritized fixes, plus visual analysis of screenshots
+- **Practical extras**: caching for repeat runs and smart recommendations tuned for AI agents to act on
+- **Battle-tested**: published on npm, listed in the [Official MCP Registry](https://registry.modelcontextprotocol.io/) and [Glama](https://glama.ai/mcp/servers), CI-tested with Vitest
+
+> **🎬 [View Interactive Demo →](https://ruslanlap.github.io/pagespeed-insights-mcp/demo/)** — See all 19 tools in action with animated examples
 > Fallback URL: [https://ruslanlap.github.io/pagespeed-insights-mcp/demo.html](https://ruslanlap.github.io/pagespeed-insights-mcp/demo.html)
 
 ## 📖 Table of Contents


### PR DESCRIPTION
## Summary
- Move copy-paste quickstart to the top of the README (first screen)
- Add a **What Makes It Different** section highlighting the 19-tool breadth vs typical 1–2-tool PSI servers
- Fix tool count (18 → 19, verified against src/index.ts); badges and demo images kept intact
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/pagespeed-insights-mcp/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->