### PR TITLE
chore: switch to Apache-2.0 license; README dedupe and cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
 
-Copyright (c) 2025 PageSpeed Insights MCP Contributors
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Get a free API key at [Google Cloud Console](https://developers.google.com/speed
 [![CI](https://github.com/ruslanlap/pagespeed-insights-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/ruslanlap/pagespeed-insights-mcp/actions/workflows/ci.yml)
 [![Documentation](https://img.shields.io/badge/docs-online-blue.svg)](https://ruslanlap.github.io/pagespeed-insights-mcp/)
 [![Live Demo](https://img.shields.io/badge/demo-live-blueviolet.svg)](https://ruslanlap.github.io/pagespeed-insights-mcp/demo/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## 🔥 What Makes It Different
 
@@ -49,63 +49,24 @@ Most PageSpeed MCP servers wrap **one** tool: "run PSI on a URL." This server sh
 ## 📖 Table of Contents
 
 - [⚡ Quick Start (Copy & Paste)](#-quick-start-copy--paste)
-  - [Claude Desktop](#claude-desktop)
-  - [Codex / OpenAI](#codex--openai)
+- [🔥 What Makes It Different](#-what-makes-it-different)
+- [⚙️ Client Configuration](#-client-configuration)
 - [📚 Documentation](#-documentation)
 - [📝 Release Notes](#-release-notes)
 - [🎯 Why You Need This](#-why-you-need-this)
 - [✨ Features](#-features)
-  - [Core Features](#core-features)
-  - [Advanced Analysis Tools (New!)](#advanced-analysis-tools-new)
 - [🚀 Quick Installation](#-quick-installation)
-  - [Option 1: Automatic Installation (Recommended)](#option-1-automatic-installation-recommended)
-  - [Option 2: Via npm or GitHub Packages](#option-2-via-npm-or-github-packages)
-    - [From npm (Public Registry)](#from-npm-public-registry)
-    - [From GitHub Packages](#from-github-packages)
-  - [🔧 Configuration](#-configuration)
-  - [📝 MCP Configuration Examples](#-mcp-configuration-examples)
-    - [For Claude Desktop](#for-claude-desktop-with-pino-pretty-logging)
-    - [For Codex](#for-codex-with-pino-pretty-logging)
-  - [Claude Desktop Configuration](#claude-desktop-configuration)
-  - [Google Antigravity](#google-antigravity)
-  - [Option 3: Docker](#option-3-docker)
 - [🔑 Getting Google API Key](#-getting-google-api-key)
 - [⚙️ Claude Desktop Configuration](#-claude-desktop-configuration)
-  - [Automatic Configuration](#automatic-configuration)
-  - [Manual Configuration](#manual-configuration)
-    - [For npm / Global Installation](#for-npm-installation-and-global-installation)
-    - [For GitHub Packages](#for-github-packages-installation)
-    - [For Docker](#for-docker)
 - [💻 Usage](#-usage)
-  - [🔍 Full Page Analysis](#-full-page-analysis)
-  - [📱 Mobile Device Analysis](#-mobile-device-analysis)
-  - [⚡ Quick Performance Overview](#-quick-performance-overview)
-  - [🖥️ Desktop Analysis](#-desktop-analysis)
-  - [🌐 Multi-Category Analysis](#-multi-category-analysis)
-  - [🎯 Smart Performance Recommendations](#-smart-performance-recommendations)
-  - [💾 Cache Management](#-cache-management)
-  - [📸 Visual Analysis](#-visual-analysis)
-  - [🎯 Element-Level Debugging](#-element-level-debugging)
-  - [🌐 Network Waterfall Analysis](#-network-waterfall-analysis)
-  - [⚡ JavaScript Performance](#-javascript-performance)
-  - [🖼️ Image Optimization Opportunities](#-image-optimization-opportunities)
-  - [🚫 Render-Blocking Resources](#-render-blocking-resources)
-  - [🔌 Third-Party Script Impact](#-third-party-script-impact)
-  - [📊 Full Lighthouse Audit](#-full-lighthouse-audit)
-- [🛠️ Available Tools](#available-tools)
-  - [Core Analysis](#core-analysis)
-  - [CrUX & Comparison](#crux--comparison)
-  - [Advanced Diagnostics](#advanced-diagnostics)
-- [📊 Complete Ratings for example.com](#complete-ratings-for-examplecom)
-- [💻 Development](#development)
-- [🔧 Troubleshooting](#troubleshooting)
-- [📋 Requirements](#requirements)
-- [🔒 Security](#security)
-- [🙏 Acknowledgments](#acknowledgments)
-- [📄 License](#license)
-- [💬 Support](#support)
-
----
+- [Available Tools](#available-tools)
+- [Development](#development)
+- [Troubleshooting](#troubleshooting)
+- [Requirements](#requirements)
+- [Security](#security)
+- [Acknowledgments](#acknowledgments)
+- [License](#license)
+- [Support](#support)
 
 ## ⚙️ Client Configuration
 
@@ -337,41 +298,7 @@ env = { GOOGLE_API_KEY = "your-google-api-key-here" }
 
 > **Note:** These examples include `pino-pretty` for better log formatting. For production use without pretty logs, see the [Logging section](#logging--pino-pretty-in-mcp-environments) below.
 
-### Claude Desktop Configuration
-
-To use this MCP server with Claude Desktop, add the following to your Claude Desktop configuration file:
-
-```json
-{
-  "mcpServers": {
-    "pagespeed-insights": {
-      "command": "npx",
-      "args": ["-y", "-p", "pino-pretty", "-p", "pagespeed-insights-mcp", "pagespeed-insights-mcp"],
-      "env": {
-        "GOOGLE_API_KEY": "your-google-api-key-here"
-      }
-    }
-  }
-}
-```
-
 ### Google Antigravity
-
-To use this MCP server with Google Antigravity, add the following configuration to your global settings file (`~/.gemini/config/mcp_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "pagespeed-insights": {
-      "command": "npx",
-      "args": ["-y", "-p", "pino-pretty", "-p", "pagespeed-insights-mcp", "pagespeed-insights-mcp"],
-      "env": {
-        "GOOGLE_API_KEY": "YOUR_GOOGLE_API_KEY"
-      }
-    }
-  }
-}
-```
 
 Example configuration files are available in the [examples](./examples/) directory.
 
@@ -408,78 +335,7 @@ To use this MCP server, you need a Google API key with the PageSpeed Insights AP
 
 ## ⚙️ Claude Desktop Configuration
 
-### Automatic Configuration
-
-If you used the `scripts/install.sh` script, the configuration was created automatically.
-
-### Manual Configuration
-
-Add the configuration to your Claude Desktop file:
-
-**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`  
-**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`  
-**Linux:** `~/.config/claude/claude_desktop_config.json`
-
-#### For npm installation and global installation
-
-```json
-{
-  "mcpServers": {
-    "pagespeed-insights": {
-      "command": "npx",
-      "args": ["-y", "-p", "pino-pretty", "-p", "pagespeed-insights-mcp", "pagespeed-insights-mcp"],
-      "env": {
-        "GOOGLE_API_KEY": "your-google-api-key-here"
-      }
-    }
-  }
-}
-```
-
-#### For GitHub Packages installation
-
-```json
-{
-  "mcpServers": {
-    "pagespeed-insights": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "-p",
-        "pino-pretty",
-        "-p",
-        "@ruslanlap/pagespeed-insights-mcp",
-        "pagespeed-insights-mcp"
-      ],
-      "env": {
-        "GOOGLE_API_KEY": "your-google-api-key-here"
-      }
-    }
-  }
-}
-```
-
-#### For Docker:
-
-```json
-{
-  "mcpServers": {
-    "pagespeed-insights": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "--env",
-        "GOOGLE_API_KEY=your-google-api-key-here",
-        "pagespeed-insights-mcp"
-      ]
-    }
-  }
-}
-```
-
-**Restart Claude Desktop** after configuration!
+Config paths: **macOS** `~/Library/Application Support/Claude/claude_desktop_config.json` · **Windows** `%APPDATA%\Claude\claude_desktop_config.json` · **Linux** `~/.config/claude/claude_desktop_config.json` — see [⚙️ Client Configuration](#%EF%B8%8F-client-configuration) above for the JSON. **Restart Claude Desktop** after editing.
 
 ## 💻 Usage
 
@@ -855,114 +711,6 @@ Analyze performance for multiple URLs with progress tracking.
 
 answer example from Claude Desktop with pagespeed-insights-mcp 🔥🔥🔥
 
-## Complete Ratings for example.com
-
-Now I have the full analysis! Here are all the ratings:
-
-### 📊 **Main Lighthouse Scores**
-
-| Category           | Score       | Status               |
-| ------------------ | ----------- | -------------------- |
-| **Performance**    | **67/100**  | 🟡 Needs Improvement |
-| **Accessibility**  | **92/100**  | 🟢 Good              |
-| **Best Practices** | **96/100**  | 🟢 Excellent         |
-| **SEO**            | **100/100** | 🟢 Perfect           |
-
-### ⚡ **Detailed Performance Metrics**
-
-| Metric                       | Value | Score                         |
-| ---------------------------- | ----- | ----------------------------- |
-| **First Contentful Paint**   | 1.2s  | 🟢 Excellent (98/100)         |
-| **Largest Contentful Paint** | 2.4s  | 🟡 Needs Improvement (75/100) |
-| **Speed Index**              | 4.8s  | 🟡 Needs Improvement (67/100) |
-| **Total Blocking Time**      | 60ms  | 🟢 Good (94/100)              |
-| **Cumulative Layout Shift**  | 0     | 🟢 Perfect (100/100)          |
-
-### ♿ **Detailed Accessibility Scores (92/100)**
-
-| Audit                           | Score    | Description                |
-| ------------------------------- | -------- | -------------------------- |
-| **Label Content Name Mismatch** | 🔴 0/1   | 2 errors with aria-label   |
-| **Unsized Images**              | 🟡 0.5/1 | 1 image without dimensions |
-| **Color Contrast**              | 🟢 1/1   | Sufficient contrast        |
-| **Button Names**                | 🟢 1/1   | Accessible button names    |
-| **Link Names**                  | 🟢 1/1   | Accessible link names      |
-| **ARIA Roles**                  | 🟢 1/1   | Correct ARIA roles         |
-| **HTML Lang**                   | 🟢 1/1   | Valid lang attribute       |
-| **Meta Viewport**               | 🟢 1/1   | Proper viewport            |
-| **Image Alt Text**              | 🟢 1/1   | Correct alt attributes     |
-| **List Items**                  | 🟢 1/1   | Proper list structure      |
-
-### 🏆 **Detailed Best Practices Scores (96/100)**
-
-| Audit                        | Score  | Status                   |
-| ---------------------------- | ------ | ------------------------ |
-| **Uses HTTPS**               | 🟢 ✓   | HTTPS is used            |
-| **HTTP Status Code**         | 🟢 1/1 | Correct 200 status       |
-| **No Console Errors**        | 🟢 1/1 | No console errors        |
-| **Valid Source Maps**        | 🟢 1/1 | Valid source maps        |
-| **No Notification Requests** | 🟢 1/1 | No notification requests |
-| **Charset Declaration**      | 🟢 1/1 | Correct encoding         |
-| **No Inspector Issues**      | 🟢 1/1 | No DevTools issues       |
-
-### 🔍 **Detailed SEO Scores (100/100)**
-
-| Audit                | Score  | Status                      |
-| -------------------- | ------ | --------------------------- |
-| **Meta Viewport**    | 🟢 1/1 | Mobile optimized            |
-| **Document Title**   | 🟢 1/1 | Title present               |
-| **Meta Description** | 🟢 1/1 | Description present         |
-| **HTTP Status Code** | 🟢 1/1 | Successful status           |
-| **Link Text**        | 🟢 1/1 | Descriptive link texts      |
-| **Crawlability**     | 🟢 1/1 | Available for indexing      |
-| **HTML Lang**        | 🟢 1/1 | Valid document language     |
-| **Hreflang**         | 🟢 1/1 | Correct hreflang attributes |
-
-### 🔧 **Main Performance Issues**
-
-| Issue                         | Affects       | Potential Savings |
-| ----------------------------- | ------------- | ----------------- |
-| **Improperly sized images**   | LCP, FCP      | 1,069 KB, 170ms   |
-| **Inefficient caching**       | Overall speed | 1,445 KB          |
-| **Forced Reflows**            | Smoothness    | 46.8ms            |
-| **JavaScript execution time** | TBT           | 338ms             |
-
-### 📈 **Network Metrics**
-
-| Metric                   | Value                  |
-| ------------------------ | ---------------------- |
-| **Server Response Time** | 120ms (🟢 Good)        |
-| **Network RTT**          | Minimal                |
-| **Main Thread Work**     | 0.9s                   |
-| **DOM Size**             | 453 elements (optimal) |
-
-### 💡 **Priority Recommendations**
-
-1. **🔴 High Priority:**
-   - Optimize image sizes (save 1+ MB)
-   - Fix aria-label mismatches for accessibility
-2. **🟡 Medium Priority:**
-   - Improve caching policy (TTL >600s)
-   - Add width/height attributes for images
-3. **🟢 Low Priority:**
-   - Optimize forced reflows in JavaScript
-
-### 🎯 **Summary**
-
-**Overall Rating: Good with potential for improvement**
-
-- **SEO**: Perfect (100/100) 🏆
-- **Best Practices**: Excellent (96/100) 🏆
-- **Accessibility**: Good (92/100) ✅
-- **Performance**: Needs attention (67/100) ⚠️
-
-The site has excellent SEO optimization and follows best practices, but needs image optimization to improve performance.
-
-**Parameters:**
-
-- `url` (required): URL of the page to analyze
-- `strategy`: "mobile" or "desktop" (default: "mobile")
-
 ## Development
 
 For better log formatting during development, it is recommended to install `pino-pretty` globally:
@@ -1055,7 +803,7 @@ A very special thank you to [@system-conf](https://github.com/system-conf) for t
 
 ## License
 
-MIT
+Apache-2.0 — see [LICENSE](./LICENSE). Patents granted by contributors under the Apache License 2.0.
 
 ## Support
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ruslanlap/pagespeed-insights-mcp",
   "version": "1.7.0",
-  "description": "MCP server for Google PageSpeed Insights & Chrome UX Report APIs — 17 tools to analyze, compare, and optimize web performance with Claude, Cursor, or any MCP-compatible AI client",
+  "description": "MCP server for Google PageSpeed Insights & Chrome UX Report APIs \u2014 17 tools to analyze, compare, and optimize web performance with Claude, Cursor, or any MCP-compatible AI client",
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
@@ -49,7 +49,7 @@
     "ttfb"
   ],
   "author": "PageSpeed Insights MCP Contributors",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ruslanlap/pagespeed-insights-mcp.git"

--- a/src/tests/cache.test.ts
+++ b/src/tests/cache.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { cache, createPSICacheKey, createCruxCacheKey } from "../cache.js";
+
+vi.mock("../env.js", () => ({
+  getEnv: () => ({
+    GOOGLE_API_KEY: "test-api-key",
+    REQUEST_TIMEOUT: 30000,
+    RETRY_ATTEMPTS: 2,
+    CACHE_TTL: 3600,
+    MAX_CONCURRENCY: 3,
+    LOG_LEVEL: "info",
+    NODE_ENV: "test",
+  }),
+}));
+
+describe("SimpleCache", () => {
+  beforeEach(() => cache.clear());
+
+  it("stores and retrieves values", () => {
+    cache.set("k", { a: 1 });
+    expect(cache.get("k")).toEqual({ a: 1 });
+  });
+
+  it("returns null on miss", () => {
+    expect(cache.get("nope")).toBeNull();
+  });
+
+  it("expires entries after TTL and deletes them lazily", () => {
+    vi.useFakeTimers();
+    cache.set("k", "v", 1000);
+    expect(cache.get("k")).toBe("v");
+    vi.advanceTimersByTime(1001);
+    expect(cache.get("k")).toBeNull(); // expired → lazy delete
+    vi.useRealTimers();
+  });
+
+  it("cleanup() removes only expired entries", () => {
+    vi.useFakeTimers();
+    cache.set("fresh", 1, 60_000);
+    cache.set("stale", 2, 1000);
+    vi.advanceTimersByTime(2000);
+    cache.cleanup();
+    expect(cache.size()).toBe(1);
+    expect(cache.get("fresh")).toBe(1);
+    vi.useRealTimers();
+  });
+
+  it("size reflects entry count", () => {
+    expect(cache.size()).toBe(0);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    expect(cache.size()).toBe(2);
+  });
+});
+
+describe("cache key builders", () => {
+  it("PSI key sorts categories so order does not change identity", () => {
+    const a = createPSICacheKey("https://x.com", "mobile", ["performance", "seo"], "en");
+    const b = createPSICacheKey("https://x.com", "mobile", ["seo", "performance"], "en");
+    expect(a).toBe(b);
+  });
+
+  it("PSI key differs by strategy/locale/url", () => {
+    const base = createPSICacheKey("https://x.com", "mobile", ["performance"], "en");
+    expect(createPSICacheKey("https://y.com", "mobile", ["performance"], "en")).not.toBe(base);
+    expect(createPSICacheKey("https://x.com", "desktop", ["performance"], "en")).not.toBe(base);
+    expect(createPSICacheKey("https://x.com", "mobile", ["performance"], "uk")).not.toBe(base);
+  });
+
+  it("CrUX key defaults formFactor", () => {
+    expect(createCruxCacheKey("https://x.com")).toBe("crux:https://x.com:default");
+    expect(createCruxCacheKey("https://x.com", "PHONE")).toBe("crux:https://x.com:PHONE");
+  });
+});

--- a/src/tests/recommendations.test.ts
+++ b/src/tests/recommendations.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import {
+  PerformanceRecommendationsEngine,
+  type RecommendationReport,
+} from "../recommendations.js";
+import type { PageSpeedInsightsResponse } from "../types.js";
+
+// Minimal valid PSI response builder — only the fields the engine reads.
+function psiResponse(opts: {
+  score?: number | null;
+  audits?: Record<string, any>;
+  auditRefs?: { id: string; weight?: number }[];
+  multirunRuns?: any[];
+} = {}): PageSpeedInsightsResponse {
+  return {
+    lighthouseResult: {
+      requestedUrl: "https://example.com",
+      configSettings: { formFactor: "mobile" },
+      categories: {
+        performance: {
+          score: opts.score ?? 0.8,
+          auditRefs: opts.auditRefs ?? [],
+        },
+      },
+      audits: opts.audits ?? {},
+    },
+    analysisUTCTimestamp: "2023-01-01T00:00:00.000Z",
+    ...(opts.multirunRuns && { multirun: { runs: opts.multirunRuns } }),
+  } as unknown as PageSpeedInsightsResponse;
+}
+
+const failingAudit = (score = 0.3) => ({
+  id: "unused-css-rules",
+  title: "Unused CSS",
+  description: "Remove unused CSS",
+  score,
+  displayValue: "1.2 KiB",
+});
+
+describe("PerformanceRecommendationsEngine.generateRecommendations", () => {
+  const engine = new PerformanceRecommendationsEngine();
+
+  it("throws without Lighthouse data", () => {
+    expect(() => engine.generateRecommendations({} as any)).toThrow(
+      /No Lighthouse data/
+    );
+  });
+
+  it("maps a known failed audit into a recommendation", () => {
+    const report = engine.generateRecommendations(
+      psiResponse({
+        audits: { "unused-css-rules": failingAudit() },
+        auditRefs: [{ id: "unused-css-rules", weight: 0.5 }],
+      })
+    );
+    expect(report.recommendations).toHaveLength(1);
+    const rec = report.recommendations[0];
+    expect(rec.id).toBe("unused-css-rules");
+    expect(rec.impact).toBe("medium");
+    expect(rec.effort).toBe("medium");
+    expect(rec.potentialSavings).toBe("1.2 KiB");
+    expect(report.url).toBe("https://example.com");
+    expect(report.strategy).toBe("mobile");
+    expect(report.overallScore).toBe(80);
+  });
+
+  it("skips passing audits (score 1), unknown audits and null scores", () => {
+    const report = engine.generateRecommendations(
+      psiResponse({
+        audits: {
+          "unused-css-rules": failingAudit(1),
+          "unknown-audit": { ...failingAudit(), id: "unknown-audit" },
+          "some-null-audit": { score: null, description: "?" },
+        },
+      })
+    );
+    expect(report.recommendations).toHaveLength(0);
+  });
+
+  it("surfaces *-insight audits that have items despite null score", () => {
+    const report = engine.generateRecommendations(
+      psiResponse({
+        audits: {
+          "foo-insight": {
+            id: "foo-insight",
+            description: "Insightful",
+            score: null,
+            details: { items: [{ note: "do this" }] },
+          },
+        },
+        auditRefs: [{ id: "foo-insight" }],
+      })
+    );
+    // Not in auditMappings table → still skipped (mapping required)
+    expect(report.recommendations).toHaveLength(0);
+  });
+
+  it("multirun noise filter drops flaky audits (passed in one run)", () => {
+    const audits = { "unused-css-rules": failingAudit() };
+    const report = engine.generateRecommendations(
+      psiResponse({
+        audits,
+        multirunRuns: [
+          { audits: { "unused-css-rules": { score: 1 } } }, // passed here
+          { audits: { "unused-css-rules": { score: 0.2 } } },
+        ],
+      })
+    );
+    expect(report.recommendations).toHaveLength(0);
+  });
+
+  it("keeps audits that fail in every run", () => {
+    const report = engine.generateRecommendations(
+      psiResponse({
+        audits: { "unused-css-rules": failingAudit() },
+        multirunRuns: [
+          { audits: { "unused-css-rules": { score: 0.2 } } },
+          { audits: { "unused-css-rules": { score: 0.4 } } },
+        ],
+      })
+    );
+    expect(report.recommendations).toHaveLength(1);
+  });
+
+  it("sorts by priority descending and flags quick wins", () => {
+    const report = engine.generateRecommendations(
+      psiResponse({
+        audits: {
+          "render-blocking-resources": {
+            id: "render-blocking-resources",
+            description: "Defer non-critical resources",
+            score: 0.2,
+            displayValue: "300 ms",
+          },
+          "unused-css-rules": failingAudit(),
+        },
+        auditRefs: [
+          { id: "render-blocking-resources", weight: 0.9 },
+          { id: "unused-css-rules", weight: 0.1 },
+        ],
+      })
+    );
+    const priorities = report.recommendations.map((r) => r.priority);
+    expect([...priorities].sort((a, b) => b - a)).toEqual(priorities);
+    // render-blocking-resources: high impact + low effort → quick win
+    expect(report.quickWins.map((r) => r.id)).toContain(
+      "render-blocking-resources"
+    );
+  });
+
+  it("summary counts by priority band", () => {
+    const report: RecommendationReport = engine.generateRecommendations(
+      psiResponse({
+        audits: {
+          "render-blocking-resources": {
+            id: "render-blocking-resources",
+            description: "d",
+            score: 0.1,
+          },
+        },
+        auditRefs: [{ id: "render-blocking-resources", weight: 1 }],
+      })
+    );
+    const s = report.summary;
+    expect(s.totalRecommendations).toBe(
+      s.highPriority + s.mediumPriority + s.lowPriority
+    );
+    expect(typeof s.estimatedImpact).toBe("string");
+  });
+});
+
+describe("PerformanceRecommendationsEngine.formatRecommendations", () => {
+  const engine = new PerformanceRecommendationsEngine();
+
+  it("renders markdown with url, score, summary and sections", () => {
+    const report = engine.generateRecommendations(
+      psiResponse({
+        audits: {
+          "render-blocking-resources": {
+            id: "render-blocking-resources",
+            description: "Defer non-critical resources",
+            score: 0.2,
+            displayValue: "300 ms",
+          },
+        },
+        auditRefs: [{ id: "render-blocking-resources", weight: 0.9 }],
+      })
+    );
+    const md = engine.formatRecommendations(report);
+    expect(md).toContain("# 🚀 Performance Recommendations");
+    expect(md).toContain("**URL:** https://example.com");
+    expect(md).toContain("**Current Score:** 80/100");
+    expect(md).toContain("## ⚡ Quick Wins");
+    expect(md).toContain("## 📋 All Recommendations");
+    expect(md).toContain("Potential Savings");
+  });
+});


### PR DESCRIPTION
## License: MIT -> Apache-2.0
- Explicit patent grant — safer for corporate users and contributors
- Updated: LICENSE (with MIT notice appendix preserving prior contributions' terms), package.json `license` field, regenerated package-lock.json, README badge + License section

## Tests included
- `src/tests/cache.test.ts`, `src/tests/recommendations.test.ts` (from the coverage work on master, carried in this branch)

## README cleanup (1057 -> 811 lines)
- Removed the "Complete Ratings for example.com" section (~110 lines of example output)
- Deduplicated mcpServers JSON config blocks: **7 -> 2** (3 were byte-identical)
- Collapsed "Claude Desktop Configuration" section into a pointer (config paths + restart note) — it duplicated Client Configuration
- Regenerated Table of Contents from actual headings (was stale/broken)

semantic-release will publish as `chore` (no version bump).