### PR TITLE
docs: credit ruslanlap as author

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025-2026 PageSpeed Insights MCP Contributors
+   Copyright 2025-2026 ruslanlap (https://github.com/ruslanlap) and PageSpeed Insights MCP Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
     "cls",
     "ttfb"
   ],
-  "author": "PageSpeed Insights MCP Contributors",
+  "author": {
+    "name": "ruslanlap",
+    "url": "https://github.com/ruslanlap"
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
LICENSE copyright line now reads:

> Copyright 2025-2026 ruslanlap (https://github.com/ruslanlap) and PageSpeed Insights MCP Contributors

Also adds `author` to package.json so npm shows the maintainer on the package page.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/pagespeed-insights-mcp/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->