### PR TITLE
docs: clarify Example Output run parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Verification inside Grok session:
 
 ## 📊 Example Output
 
-Real `analyze_page_speed` result for **github.com** (mobile, single run):
+Real `analyze_page_speed` results for **github.com** — two runs: `strategy: "mobile"` (metrics table) and `strategy: "both"` (mobile + desktop category scores). CrUX numbers come from `get_origin_crux`:
 
 **Lighthouse lab scores:**
 
@@ -170,6 +170,8 @@ Real `analyze_page_speed` result for **github.com** (mobile, single run):
 | Interaction to Next Paint | 243 ms |
 | Cumulative Layout Shift | 0.02 |
 
+> Results vary between runs — Lighthouse lab data is noisy (a single run is one sample). Use `runs: 3-5` for medians.
+>
 > Lab vs field: Lighthouse throttles the connection (hence 54/100 mobile), while CrUX shows how actual GitHub visitors experience it — both views come straight from this server's tools.
 
 ## 📚 Documentation


### PR DESCRIPTION
Follow-up to #85 (Codex/Copilot review):

1. **Strategy labeling** — the tables mix two runs (`strategy: "both"` for category scores, separate `mobile` run for metrics) plus `get_origin_crux` for field data. The intro now says exactly that instead of "mobile, single run".
2. **Restored the variability disclaimer** ("results vary between runs, use runs: 3-5") that was dropped when the section was rewritten.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/pagespeed-insights-mcp/pull/86" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->