### PR TITLE
fix(tools): clear_cache openWorldHint false — in-memory cache only

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -251,7 +251,7 @@ export class PageSpeedInsightsServer {
               properties: {},
               additionalProperties: false
             },
-            annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true }
+            annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false }  // in-memory cache only — no network/filesystem
           },
           {
             name: "get_recommendations",


### PR DESCRIPTION
Follow-up to #91 (Copilot "Needs a closer look" review): `clear_cache` only resets the in-memory `SimpleCache` (a `Map`) — no network or filesystem access — so `openWorldHint: true` misdescribed its behavior. Now `false`.

## Verification
- tsc clean, 76/76 tests pass
- Only annotation value changed; no handler/schema logic touched
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/pagespeed-insights-mcp/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->