### PR TITLE
ci(release): upload dist assets and verify release integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,43 @@ jobs:
             echo "ℹ️ No new release (HEAD is not tagged $RELEASE_TAG). Skipping publish."
           fi
 
+      - name: Upload release assets and verify release integrity
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          # Runs in the release job, on the release commit — immune to the
+          # GITHUB_TOKEN-tag-doesn't-trigger-workflows problem.
+          RELEASE_TAG="v$(node -p "require('./package.json').version")"
+          if ! git describe --tags --exact-match HEAD 2>/dev/null | grep -qF "$RELEASE_TAG"; then
+            echo "ℹ️ No new release — nothing to verify."
+            exit 0
+          fi
+
+          ASSET="pagespeed-insights-mcp-${RELEASE_TAG}-dist.tar.gz"
+          tar -czf "$ASSET" dist package.json README.md
+          sha256sum "$ASSET" > "${ASSET}.sha256"
+          gh release upload "$RELEASE_TAG" "$ASSET" "${ASSET}.sha256" --clobber
+          echo "📦 Uploaded: $ASSET (+ .sha256)"
+
+          # ── Watchdog: a release must never be "empty" ──
+          sleep 5
+          INFO=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")
+          ASSET_COUNT=$(echo "$INFO" | jq '.assets | length')
+          BODY_LEN=$(echo "$INFO" | jq '.body | length')
+          echo "assets=$ASSET_COUNT body_len=$BODY_LEN"
+          [ "$ASSET_COUNT" -ge 2 ] || { echo "❌ FAIL: release $RELEASE_TAG has only $ASSET_COUNT assets"; exit 1; }
+          [ "$BODY_LEN" -gt 50 ]   || { echo "❌ FAIL: release $RELEASE_TAG body is empty/short"; exit 1; }
+
+          # npm must carry the new version (retry: registry propagation)
+          EXPECTED="${RELEASE_TAG#v}"
+          for i in 1 2 3 4 5; do
+            NPM_VER=$(npm view pagespeed-insights-mcp@latest version 2>/dev/null || echo "none")
+            [ "$NPM_VER" = "$EXPECTED" ] && break
+            echo "npm latest is '$NPM_VER', expected '$EXPECTED' — retry $i/5"; sleep 30
+          done
+          [ "$NPM_VER" = "$EXPECTED" ] || { echo "❌ FAIL: npm latest is '$NPM_VER', expected '$EXPECTED'"; exit 1; }
+          echo "✅ Release $RELEASE_TAG verified: assets + notes + npm $NPM_VER"
+
   docker:
     name: Build Docker Image
     needs: [test, security]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruslanlap/pagespeed-insights-mcp",
-  "version": "1.7.2",
+  "version": "1.7.1",
   "description": "MCP server for Google PageSpeed Insights & Chrome UX Report APIs — 17 tools to analyze, compare, and optimize web performance with Claude, Cursor, or any MCP-compatible AI client",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Problem
Every release shipped with **0 assets** and nothing caught it — discovered on v1.7.1/v1.7.2 (empty attachments).

## Fix
Post-publish step in the **release job itself** (runs on the release commit → immune to the GITHUB_TOKEN-tag-doesn't-trigger-workflows problem):

1. **Assets**: tar `dist/ + package.json + README.md` → upload as `pagespeed-insights-mcp-vX.Y.Z-dist.tar.gz` + `.sha256` checksum
2. **Watchdog gate** (fails CI loudly):
   - release must have ≥2 assets
   - release body must be non-empty (>50 chars)
   - npm `latest` must carry the new version (5×30s retries for registry propagation)

## Backfill
v1.7.1 and v1.7.2 assets uploaded manually (verified: 201).

## Notes
- No new dependencies (uses preinstalled `gh`/`jq`/`tar`)
- First release to exercise the full path will be the next `fix:`/`feat:` merge
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/pagespeed-insights-mcp/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->